### PR TITLE
example points to v4, readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Coraza Coreruleset
-
+Coraza Coreruleset is a Go package meant to provide the [OWASP CRS](https://github.com/coreruleset/coreruleset) in an easy and consumable way to be embedded in a Go application. Alongside the unmodified CRS, the [Coraza configuration file](https://github.com/corazawaf/coraza/blob/main/coraza.conf-recommended) is also provided.
 ## Usage
 
 In order to use CRS, you need to load the coreruleset FileSystem:

--- a/example/go.mod
+++ b/example/go.mod
@@ -3,7 +3,7 @@ module github.com/corazawaf/coraza-coreruleset/v4/example
 go 1.18
 
 require (
-	github.com/corazawaf/coraza-coreruleset v0.0.0-20240226094324-415b1017abdc
+	github.com/corazawaf/coraza-coreruleset/v4 v4.0.0
 	github.com/corazawaf/coraza/v3 v3.1.0
 )
 

--- a/example/go.sum
+++ b/example/go.sum
@@ -1,5 +1,5 @@
-github.com/corazawaf/coraza-coreruleset v0.0.0-20240226094324-415b1017abdc h1:OlJhrgI3I+FLUCTI3JJW8MoqyM78WbqJjecqMnqG+wc=
-github.com/corazawaf/coraza-coreruleset v0.0.0-20240226094324-415b1017abdc/go.mod h1:7rsocqNDkTCira5T0M7buoKR2ehh7YZiPkzxRuAgvVU=
+github.com/corazawaf/coraza-coreruleset/v4 v4.0.0 h1:1jmrC65x7rJwSvxySaWyk84T45PwBvNe7188bfdnTCA=
+github.com/corazawaf/coraza-coreruleset/v4 v4.0.0/go.mod h1:RQMGurig+irQq7v21yq7rM/9SAEf1bT6hCSplJ0ByKY=
 github.com/corazawaf/coraza/v3 v3.1.0 h1:CB6YxNXdbZjUJS/0FVFoFvS8eOVFbIvlNuHNC5dh88c=
 github.com/corazawaf/coraza/v3 v3.1.0/go.mod h1:S0bhYQfTu1Ew3YKdI37X1WWu6t4En4Tvw28aKyQFJaU=
 github.com/corazawaf/libinjection-go v0.1.3 h1:PUplAYho1BBl0tIVbhDsNRuVGIeUYSiCEc9oQpb2rJU=

--- a/example/main.go
+++ b/example/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	coreruleset "github.com/corazawaf/coraza-coreruleset"
+	coreruleset "github.com/corazawaf/coraza-coreruleset/v4"
 	"github.com/corazawaf/coraza/v3"
 )
 


### PR DESCRIPTION
This PR:
- Makes the example work with the tag
- Adds a bit more context on the readme (follows [slack question](https://owasp.slack.com/archives/C02BXH135AT/p1709133748884199))

```
Repo/coraza-coreruleset/example  example-v4-readme ✔                                                                                                                                                                                                                     
▶ go run main.go
Success
```