### PR TITLE
Adds DownloadCorazaConfig, CI changes check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,3 +29,25 @@ jobs:
           cache: true
       - name: Tests
         run: go run mage.go test
+
+  check_changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.20.x
+      - name: Download Coraza config
+        run: go run mage.go downloadCorazaConfig
+      - name: Download CRS
+        run: go run mage.go downloadCRS
+      - name: Check if there are changes
+        id: changes
+        uses: UnicornGlobal/has-changes-action@v1.0.11
+      - name: Process changes
+        if: steps.changes.outputs.changed == 1
+        run: |
+          echo "Uncommited changes detected. Please commit and push the changes."
+          exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,15 +39,13 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.20.x
-      - name: Download Coraza config
-        run: go run mage.go downloadCorazaConfig
-      - name: Download CRS
-        run: go run mage.go downloadCRS
+      - name: Download CRS and Coraza config
+        run: go run mage.go downloadDeps
       - name: Check if there are changes
         id: changes
         uses: UnicornGlobal/has-changes-action@v1.0.11
       - name: Process changes
         if: steps.changes.outputs.changed == 1
         run: |
-          echo "Uncommited changes detected. Please commit and push the changes."
+          echo 'Uncommited changes detected. Run `go run mage.go downloadDeps` to check the changes and commit them.'
           exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,11 +41,12 @@ jobs:
           go-version: 1.20.x
       - name: Download CRS and Coraza config
         run: go run mage.go downloadDeps
+      # Ref: https://gist.github.com/somidad/3ce6e8a7b7d77ac8fa7fad583003d6f5
       - name: Check if there are changes
         id: changes
-        uses: UnicornGlobal/has-changes-action@v1.0.11
+        run: echo "changed=$(git status --porcelain | wc -l)" >> $GITHUB_OUTPUT
       - name: Process changes
-        if: steps.changes.outputs.changed == 1
+        if: steps.changes.outputs.changed != 0 
         run: |
           echo 'Uncommited changes detected. Run `go run mage.go downloadDeps` to check the changes and commit them.'
           exit 1

--- a/README.md
+++ b/README.md
@@ -48,3 +48,9 @@ func main() {
 1. Update the `crsVersion` constant in [`version.go`](/version.go) with the wished [CRS](https://github.com/coreruleset/coreruleset) commit SHA.
 2. Run `mage downloadCRS`.
 3. Commit your changes.
+
+## How to update to a newer Coraza config version
+
+1. Update the `corazaVersion` constant in [`version.go`](/version.go) with the wished [Coraza](https://github.com/corazawaf/coraza) commit SHA or tag.
+2. Run `mage downloadCorazaConfig`.
+3. Commit your changes.

--- a/README.md
+++ b/README.md
@@ -47,4 +47,5 @@ func main() {
 
 1. Update the `crsVersion` and `corazaVersion` constants in [`version.go`](/version.go) with the wished [CRS](https://github.com/coreruleset/coreruleset) and [Coraza](https://github.com/corazawaf/coraza) commit SHA or tags.
 2. Run `go run mage.go downloadDeps`.
+3. Double check the changes made under the `/rules` and `/tests` directories.
 3. Commit your changes.

--- a/README.md
+++ b/README.md
@@ -43,14 +43,8 @@ func main() {
 }
 ```
 
-## How to update to a newer CRS version
+## How to update to a newer CRS and Coraza config version
 
-1. Update the `crsVersion` constant in [`version.go`](/version.go) with the wished [CRS](https://github.com/coreruleset/coreruleset) commit SHA.
-2. Run `mage downloadCRS`.
-3. Commit your changes.
-
-## How to update to a newer Coraza config version
-
-1. Update the `corazaVersion` constant in [`version.go`](/version.go) with the wished [Coraza](https://github.com/corazawaf/coraza) commit SHA or tag.
-2. Run `mage downloadCorazaConfig`.
+1. Update the `crsVersion` and `corazaVersion` constants in [`version.go`](/version.go) with the wished [CRS](https://github.com/coreruleset/coreruleset) and [Coraza](https://github.com/corazawaf/coraza) commit SHA or tags.
+2. Run `go run mage.go downloadDeps`.
 3. Commit your changes.

--- a/rules/@coraza.conf-recommended
+++ b/rules/@coraza.conf-recommended
@@ -231,7 +231,7 @@ SecAuditLogParts ABIJDEFHZ
 SecAuditLogType Serial
 
 
-# -- Miscellaneous -----------------------------------------------------------
+# -- Miscellaneous ------------------------------------------------------------
 
 # Use the most commonly used application/x-www-form-urlencoded parameter
 # separator. There's probably only one application somewhere that uses

--- a/rules/@coraza.conf-recommended
+++ b/rules/@coraza.conf-recommended
@@ -231,7 +231,7 @@ SecAuditLogParts ABIJDEFHZ
 SecAuditLogType Serial
 
 
-# -- Miscellaneous ------------------------------------------------------------
+# -- Miscellaneous -----------------------------------------------------------
 
 # Use the most commonly used application/x-www-form-urlencoded parameter
 # separator. There's probably only one application somewhere that uses

--- a/version.go
+++ b/version.go
@@ -7,5 +7,6 @@
 package main
 
 const (
-	crsVersion = "1d95422bb31983a5290720b7fb662ce3dd51f753"
+	crsVersion    = "1d95422bb31983a5290720b7fb662ce3dd51f753"
+	corazaVersion = "v3.1.0"
 )

--- a/version.go
+++ b/version.go
@@ -7,6 +7,6 @@
 package main
 
 const (
-	crsVersion    = "1d95422bb31983a5290720b7fb662ce3dd51f753"
+	crsVersion    = "v4.0.0"
 	corazaVersion = "v3.1.0"
 )


### PR DESCRIPTION
- Adds `DownloadCorazaConfig` to automate the Coraza config update
- Proposes to add to the CI a consistency check between the CRS/Coraza versions and the files actually committed. `DownloadCorazaConfig` and `DownloadCRS` will be executed and the CI should fail if uncommitted changes are detected