### PR TITLE
Update to CRS v4.10.0

### DIFF
--- a/rules/@crs-setup.conf.example
+++ b/rules/@crs-setup.conf.example
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -181,7 +181,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:tx.blocking_paranoia_level=1"
 
 
@@ -209,7 +209,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:tx.detection_paranoia_level=1"
 
 
@@ -235,7 +235,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:tx.enforce_bodyproc_urlencoded=1"
 
 
@@ -270,7 +270,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:tx.critical_anomaly_score=5,\
 #    setvar:tx.error_anomaly_score=4,\
 #    setvar:tx.warning_anomaly_score=3,\
@@ -324,7 +324,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:tx.inbound_anomaly_score_threshold=5,\
 #    setvar:tx.outbound_anomaly_score_threshold=4"
 
@@ -385,7 +385,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:tx.reporting_level=4"
 
 
@@ -417,7 +417,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:tx.early_blocking=1"
 
 
@@ -438,7 +438,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:tx.enable_default_collections=1"
 
 
@@ -471,7 +471,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:'tx.allowed_methods=GET HEAD POST OPTIONS'"
 
 # Content-Types that a client is allowed to send in a request.
@@ -509,7 +509,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    nolog,\
 #    tag:'OWASP_CRS',\
 #    ctl:ruleRemoveById=920420,\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    chain"
 #    SecRule REQUEST_URI "@rx ^/foo/bar" \
 #        "t:none"
@@ -523,7 +523,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |text/xml| |application/xml| |application/soap+xml| |application/json|'"
 
 # Allowed HTTP versions.
@@ -539,7 +539,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:'tx.allowed_http_versions=HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0 HTTP/3 HTTP/3.0'"
 
 # Forbidden file extensions.
@@ -563,7 +563,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pem/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .swp/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'"
 
 # Restricted request headers.
@@ -608,7 +608,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:'tx.restricted_headers_basic=/content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/'"
 #
 # [ Extended ]
@@ -634,7 +634,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:'tx.restricted_headers_extended=/accept-charset/'"
 
 # Content-Types charsets that a client is allowed to send in a request.
@@ -648,7 +648,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:'tx.allowed_request_content_type_charset=|utf-8| |iso-8859-1| |iso-8859-15| |windows-1252|'"
 
 #
@@ -674,7 +674,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:tx.max_num_args=255"
 
 # Block request if the length of any argument name is too high
@@ -688,7 +688,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:tx.arg_name_length=100"
 
 # Block request if the length of any argument value is too high
@@ -702,7 +702,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:tx.arg_length=400"
 
 # Block request if the total length of all combined arguments is too high
@@ -716,7 +716,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:tx.total_arg_length=64000"
 
 # Block request if the file size of any individual uploaded file is too high
@@ -730,7 +730,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:tx.max_file_size=1048576"
 
 # Block request if the total size of all combined uploaded files is too high
@@ -744,7 +744,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:tx.combined_file_sizes=1048576"
 
 
@@ -784,7 +784,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:tx.sampling_percentage=100"
 
 
@@ -805,7 +805,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:tx.crs_validate_utf8_encoding=1"
 
 # -- [[ Skip Checking Responses ]] ------------------------------------------------
@@ -827,7 +827,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.9.0',\
+#    ver:'OWASP_CRS/4.10.0',\
 #    setvar:tx.crs_skip_response_analysis=1"
 
 #
@@ -848,5 +848,5 @@ SecAction \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
-    setvar:tx.crs_setup_version=490"
+    ver:'OWASP_CRS/4.10.0',\
+    setvar:tx.crs_setup_version=4100"

--- a/rules/@owasp_crs/REQUEST-901-INITIALIZATION.conf
+++ b/rules/@owasp_crs/REQUEST-901-INITIALIZATION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -7,7 +7,7 @@
 # Apache Software License (ASL) version 2
 # Please see the enclosed LICENSE file for full details.
 # ------------------------------------------------------------------------
-SecComponentSignature "OWASP_CRS/4.9.0"
+SecComponentSignature "OWASP_CRS/4.10.0"
 SecRule &TX:crs_setup_version "@eq 0" \
     "id:901001,\
     phase:1,\
@@ -17,7 +17,7 @@ SecRule &TX:crs_setup_version "@eq 0" \
     auditlog,\
     msg:'CRS is deployed without configuration! Please copy the crs-setup.conf.example template to crs-setup.conf, and include the crs-setup.conf file in your webserver configuration before including the CRS rules. See the INSTALL file in the CRS directory for detailed instructions',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL'"
 SecRule &TX:inbound_anomaly_score_threshold "@eq 0" \
     "id:901100,\
@@ -25,7 +25,7 @@ SecRule &TX:inbound_anomaly_score_threshold "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.inbound_anomaly_score_threshold=5'"
 SecRule &TX:outbound_anomaly_score_threshold "@eq 0" \
     "id:901110,\
@@ -33,7 +33,7 @@ SecRule &TX:outbound_anomaly_score_threshold "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.outbound_anomaly_score_threshold=4'"
 SecRule &TX:reporting_level "@eq 0" \
     "id:901111,\
@@ -41,7 +41,7 @@ SecRule &TX:reporting_level "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.reporting_level=4'"
 SecRule &TX:early_blocking "@eq 0" \
     "id:901115,\
@@ -49,7 +49,7 @@ SecRule &TX:early_blocking "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.early_blocking=0'"
 SecRule &TX:blocking_paranoia_level "@eq 0" \
     "id:901120,\
@@ -57,7 +57,7 @@ SecRule &TX:blocking_paranoia_level "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.blocking_paranoia_level=1'"
 SecRule &TX:detection_paranoia_level "@eq 0" \
     "id:901125,\
@@ -65,7 +65,7 @@ SecRule &TX:detection_paranoia_level "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.detection_paranoia_level=%{TX.blocking_paranoia_level}'"
 SecRule &TX:sampling_percentage "@eq 0" \
     "id:901130,\
@@ -73,7 +73,7 @@ SecRule &TX:sampling_percentage "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.sampling_percentage=100'"
 SecRule &TX:critical_anomaly_score "@eq 0" \
     "id:901140,\
@@ -81,7 +81,7 @@ SecRule &TX:critical_anomaly_score "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.critical_anomaly_score=5'"
 SecRule &TX:error_anomaly_score "@eq 0" \
     "id:901141,\
@@ -89,7 +89,7 @@ SecRule &TX:error_anomaly_score "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.error_anomaly_score=4'"
 SecRule &TX:warning_anomaly_score "@eq 0" \
     "id:901142,\
@@ -97,7 +97,7 @@ SecRule &TX:warning_anomaly_score "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.warning_anomaly_score=3'"
 SecRule &TX:notice_anomaly_score "@eq 0" \
     "id:901143,\
@@ -105,7 +105,7 @@ SecRule &TX:notice_anomaly_score "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.notice_anomaly_score=2'"
 SecRule &TX:allowed_methods "@eq 0" \
     "id:901160,\
@@ -113,7 +113,7 @@ SecRule &TX:allowed_methods "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.allowed_methods=GET HEAD POST OPTIONS'"
 SecRule &TX:allowed_request_content_type "@eq 0" \
     "id:901162,\
@@ -121,7 +121,7 @@ SecRule &TX:allowed_request_content_type "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |text/xml| |application/xml| |application/soap+xml| |application/json|'"
 SecRule &TX:allowed_request_content_type_charset "@eq 0" \
     "id:901168,\
@@ -129,7 +129,7 @@ SecRule &TX:allowed_request_content_type_charset "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.allowed_request_content_type_charset=|utf-8| |iso-8859-1| |iso-8859-15| |windows-1252|'"
 SecRule &TX:allowed_http_versions "@eq 0" \
     "id:901163,\
@@ -137,7 +137,7 @@ SecRule &TX:allowed_http_versions "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.allowed_http_versions=HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0 HTTP/3 HTTP/3.0'"
 SecRule &TX:restricted_extensions "@eq 0" \
     "id:901164,\
@@ -145,7 +145,7 @@ SecRule &TX:restricted_extensions "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pem/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .swp/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'"
 SecRule &TX:restricted_headers_basic "@eq 0" \
     "id:901165,\
@@ -153,7 +153,7 @@ SecRule &TX:restricted_headers_basic "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.restricted_headers_basic=/content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/'"
 SecRule &TX:restricted_headers_extended "@eq 0" \
     "id:901171,\
@@ -161,7 +161,7 @@ SecRule &TX:restricted_headers_extended "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.restricted_headers_extended=/accept-charset/'"
 SecRule &TX:enforce_bodyproc_urlencoded "@eq 0" \
     "id:901167,\
@@ -169,7 +169,7 @@ SecRule &TX:enforce_bodyproc_urlencoded "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.enforce_bodyproc_urlencoded=0'"
 SecRule &TX:crs_validate_utf8_encoding "@eq 0" \
     "id:901169,\
@@ -177,7 +177,7 @@ SecRule &TX:crs_validate_utf8_encoding "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.crs_validate_utf8_encoding=0'"
 SecRule &TX:crs_skip_response_analysis "@eq 0" \
     "id:901170,\
@@ -185,7 +185,7 @@ SecRule &TX:crs_skip_response_analysis "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.crs_skip_response_analysis=0'"
 SecAction \
     "id:901200,\
@@ -194,7 +194,7 @@ SecAction \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.blocking_inbound_anomaly_score=0',\
     setvar:'tx.detection_inbound_anomaly_score=0',\
     setvar:'tx.inbound_anomaly_score_pl1=0',\
@@ -222,7 +222,7 @@ SecRule TX:ENABLE_DEFAULT_COLLECTIONS "@eq 1" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.ua_hash=%{REQUEST_HEADERS.User-Agent}',\
     chain"
     SecRule TX:ua_hash "@unconditionalMatch" \
@@ -238,7 +238,7 @@ SecRule REQBODY_PROCESSOR "!@rx (?:URLENCODED|MULTIPART|XML|JSON)" \
     msg:'Enabling body inspection',\
     tag:'OWASP_CRS',\
     ctl:forceRequestBodyVariable=On,\
-    ver:'OWASP_CRS/4.9.0'"
+    ver:'OWASP_CRS/4.10.0'"
 SecRule TX:enforce_bodyproc_urlencoded "@eq 1" \
     "id:901350,\
     phase:1,\
@@ -248,7 +248,7 @@ SecRule TX:enforce_bodyproc_urlencoded "@eq 1" \
     noauditlog,\
     msg:'Enabling forced body inspection for ASCII content',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     chain"
     SecRule REQBODY_PROCESSOR "!@rx (?:URLENCODED|MULTIPART|XML|JSON)" \
         "ctl:requestBodyProcessor=URLENCODED"
@@ -258,7 +258,7 @@ SecRule TX:sampling_percentage "@eq 100" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     skipAfter:END-SAMPLING"
 SecRule UNIQUE_ID "@rx ^[a-f]*([0-9])[a-f]*([0-9])" \
     "id:901410,\
@@ -268,7 +268,7 @@ SecRule UNIQUE_ID "@rx ^[a-f]*([0-9])[a-f]*([0-9])" \
     t:sha1,t:hexEncode,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'TX.sampling_rnd100=%{TX.1}%{TX.2}'"
 SecRule TX:sampling_rnd100 "!@lt %{tx.sampling_percentage}" \
     "id:901450,\
@@ -279,7 +279,7 @@ SecRule TX:sampling_rnd100 "!@lt %{tx.sampling_percentage}" \
     msg:'Sampling: Disable the rule engine based on sampling_percentage %{TX.sampling_percentage} and random number %{TX.sampling_rnd100}',\
     tag:'OWASP_CRS',\
     ctl:ruleRemoveByTag=OWASP_CRS,\
-    ver:'OWASP_CRS/4.9.0'"
+    ver:'OWASP_CRS/4.10.0'"
 SecMarker "END-SAMPLING"
 SecRule TX:detection_paranoia_level "@lt %{tx.blocking_paranoia_level}" \
     "id:901500,\
@@ -290,4 +290,4 @@ SecRule TX:detection_paranoia_level "@lt %{tx.blocking_paranoia_level}" \
     log,\
     msg:'Detection paranoia level configured is lower than the paranoia level itself. This is illegal. Blocking request. Aborting',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0'"
+    ver:'OWASP_CRS/4.10.0'"

--- a/rules/@owasp_crs/REQUEST-905-COMMON-EXCEPTIONS.conf
+++ b/rules/@owasp_crs/REQUEST-905-COMMON-EXCEPTIONS.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -18,7 +18,7 @@ SecRule REQUEST_LINE "@streq GET /" \
     tag:'platform-apache',\
     tag:'attack-generic',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     chain"
     SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
         "t:none,\
@@ -35,7 +35,7 @@ SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
     tag:'platform-apache',\
     tag:'attack-generic',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     chain"
     SecRule REQUEST_HEADERS:User-Agent "@endsWith (internal dummy connection)" \
         "t:none,\

--- a/rules/@owasp_crs/REQUEST-911-METHOD-ENFORCEMENT.conf
+++ b/rules/@owasp_crs/REQUEST-911-METHOD-ENFORCEMENT.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -7,8 +7,8 @@
 # Apache Software License (ASL) version 2
 # Please see the enclosed LICENSE file for full details.
 # ------------------------------------------------------------------------
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:911011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:911012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:911011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:911012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
 SecRule REQUEST_METHOD "!@within %{tx.allowed_methods}" \
     "id:911100,\
     phase:1,\
@@ -23,13 +23,13 @@ SecRule REQUEST_METHOD "!@within %{tx.allowed_methods}" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/274',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:911013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:911014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:911015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:911016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:911017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:911018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:911013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:911014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:911015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:911016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:911017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:911018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
 SecMarker "END-REQUEST-911-METHOD-ENFORCEMENT"

--- a/rules/@owasp_crs/REQUEST-913-SCANNER-DETECTION.conf
+++ b/rules/@owasp_crs/REQUEST-913-SCANNER-DETECTION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -7,8 +7,8 @@
 # Apache Software License (ASL) version 2
 # Please see the enclosed LICENSE file for full details.
 # ------------------------------------------------------------------------
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:913011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:913012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:913011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:913012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
 SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners-user-agents.data" \
     "id:913100,\
     phase:1,\
@@ -25,13 +25,13 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners-user-agents.data" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/224/541/310',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:913013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:913014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:913015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:913016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:913017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:913018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:913013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:913014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:913015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:913016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:913017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:913018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
 SecMarker "END-REQUEST-913-SCANNER-DETECTION"

--- a/rules/@owasp_crs/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/@owasp_crs/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -7,8 +7,8 @@
 # Apache Software License (ASL) version 2
 # Please see the enclosed LICENSE file for full details.
 # ------------------------------------------------------------------------
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:920011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:920012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:920011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:920012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 SecRule REQUEST_LINE "!@rx (?i)^(?:get /[^#\?]*(?:\?[^\s\x0b#]*)?(?:#[^\s\x0b]*)?|(?:connect (?:(?:[0-9]{1,3}\.){3}[0-9]{1,3}\.?(?::[0-9]+)?|[\--9A-Z_a-z]+:[0-9]+)|options \*|[a-z]{3,10}[\s\x0b]+(?:[0-9A-Z_a-z]{3,7}?://[\--9A-Z_a-z]*(?::[0-9]+)?)?/[^#\?]*(?:\?[^\s\x0b#]*)?(?:#[^\s\x0b]*)?)[\s\x0b]+[\.-9A-Z_a-z]+)$" \
     "id:920100,\
     phase:1,\
@@ -23,7 +23,7 @@ SecRule REQUEST_LINE "!@rx (?i)^(?:get /[^#\?]*(?:\?[^\s\x0b#]*)?(?:#[^\s\x0b]*)
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 SecRule FILES|FILES_NAMES "!@rx (?i)^(?:&(?:(?:[acegilnorsuz]acut|[aeiou]grav|[aino]tild)e|[c-elnr-tz]caron|(?:[cgklnr-t]cedi|[aeiouy]um)l|[aceg-josuwy]circ|[au]ring|a(?:mp|pos)|nbsp|oslash);|[^\"';=\x5c])*$" \
@@ -40,7 +40,7 @@ SecRule FILES|FILES_NAMES "!@rx (?i)^(?:&(?:(?:[acegilnorsuz]acut|[aeiou]grav|[a
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule REQUEST_HEADERS:Content-Length "!@rx ^\d+$" \
@@ -57,7 +57,7 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^\d+$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
@@ -74,7 +74,7 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     chain"
     SecRule REQUEST_HEADERS:Content-Length "!@rx ^0?$" \
@@ -94,7 +94,7 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     chain"
     SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" \
@@ -114,7 +114,7 @@ SecRule REQUEST_PROTOCOL "!@within HTTP/2 HTTP/2.0 HTTP/3 HTTP/3.0" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_METHOD "@streq POST" \
@@ -136,7 +136,7 @@ SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'WARNING',\
     chain"
     SecRule &REQUEST_HEADERS:Content-Length "!@eq 0" \
@@ -157,7 +157,7 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx (\d+)-(\d+)" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'WARNING',\
     chain"
     SecRule TX:2 "@lt %{tx.1}" \
@@ -176,7 +176,7 @@ SecRule REQUEST_HEADERS:Connection "@rx \b(?:keep-alive|close),\s?(?:keep-alive|
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 SecRule REQUEST_URI_RAW "@rx \x25" \
@@ -193,7 +193,7 @@ SecRule REQUEST_URI_RAW "@rx \x25" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/267/72',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     chain"
     SecRule REQUEST_URI_RAW "@rx ^(.*)/(?:[^\?]+)?(\?.*)?$" \
@@ -217,7 +217,7 @@ SecRule REQUEST_BASENAME "!@rx ^.*%.*\.[^\s\x0b\.]+$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/267/72',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     chain"
     SecRule TX:0 "@validateUrlEncoding" \
@@ -237,7 +237,7 @@ SecRule TX:CRS_VALIDATE_UTF8_ENCODING "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/267',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_FILENAME|ARGS|ARGS_NAMES "@validateUtf8Encoding" \
@@ -257,7 +257,7 @@ SecRule REQUEST_URI|REQUEST_BODY "@rx (?i)%uff[0-9a-f]{2}" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/267/72',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 1-255" \
@@ -274,7 +274,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 1-255" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule &REQUEST_HEADERS:Host "@eq 0" \
@@ -291,7 +291,7 @@ SecRule &REQUEST_HEADERS:Host "@eq 0" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}',\
     skipAfter:END-HOST-CHECK"
@@ -308,7 +308,7 @@ SecRule REQUEST_HEADERS:Host "@rx ^$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecMarker "END-HOST-CHECK"
@@ -325,7 +325,7 @@ SecRule REQUEST_HEADERS:Accept "@rx ^$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'NOTICE',\
     chain"
     SecRule REQUEST_METHOD "!@rx ^OPTIONS$" \
@@ -346,7 +346,7 @@ SecRule REQUEST_HEADERS:Accept "@rx ^$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'NOTICE',\
     chain"
     SecRule REQUEST_METHOD "!@rx ^OPTIONS$" \
@@ -367,7 +367,7 @@ SecRule REQUEST_HEADERS:User-Agent "@rx ^$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'NOTICE',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.notice_anomaly_score}'"
 SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
@@ -383,7 +383,7 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'NOTICE',\
     chain"
     SecRule &REQUEST_HEADERS:Content-Type "@eq 0" \
@@ -404,7 +404,7 @@ SecRule REQUEST_HEADERS:Host "@rx (?:^([\d.]+|\[[\da-f:]+\]|[\da-f:]+)(:[\d]+)?$
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 SecRule &TX:MAX_NUM_ARGS "@eq 1" \
@@ -421,7 +421,7 @@ SecRule &TX:MAX_NUM_ARGS "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     chain"
     SecRule &ARGS "@gt %{tx.max_num_args}" \
@@ -441,7 +441,7 @@ SecRule &TX:ARG_NAME_LENGTH "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     chain"
     SecRule ARGS_NAMES "@gt %{tx.arg_name_length}" \
@@ -461,7 +461,7 @@ SecRule &TX:ARG_LENGTH "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     chain"
     SecRule ARGS "@gt %{tx.arg_length}" \
@@ -481,7 +481,7 @@ SecRule &TX:TOTAL_ARG_LENGTH "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     chain"
     SecRule ARGS_COMBINED_SIZE "@gt %{tx.total_arg_length}" \
@@ -500,7 +500,7 @@ SecRule &TX:MAX_FILE_SIZE "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     chain"
     SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)multipart/form-data" \
@@ -522,7 +522,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     chain"
     SecRule FILES_COMBINED_SIZE "@gt %{tx.combined_file_sizes}" \
@@ -543,7 +543,7 @@ SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+*-]+(?:\s?;\s*(?:action|bounda
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
@@ -562,7 +562,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.content_type=|%{tx.0}|',\
     chain"
@@ -585,7 +585,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx charset\s*=\s*[\"']?([^;\"'\s]+)" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.content_type_charset=|%{tx.1}|',\
     chain"
@@ -608,7 +608,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx charset.*?charset" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule REQUEST_PROTOCOL "!@within %{tx.allowed_http_versions}" \
@@ -626,7 +626,7 @@ SecRule REQUEST_PROTOCOL "!@within %{tx.allowed_http_versions}" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule REQUEST_BASENAME "@rx \.([^.]+)$" \
@@ -645,7 +645,7 @@ SecRule REQUEST_BASENAME "@rx \.([^.]+)$" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.extension=.%{tx.1}/',\
     chain"
@@ -667,7 +667,7 @@ SecRule REQUEST_FILENAME "@rx \.[^.~]+~(?:/.*|)$" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
@@ -686,7 +686,7 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.header_name_920450_%{tx.0}=/%{tx.0}/',\
     chain"
@@ -707,7 +707,7 @@ SecRule REQUEST_HEADERS:Accept-Encoding "@gt 100" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule REQUEST_HEADERS:Accept "!@rx ^(?:(?:\*|[^!\"\(\),/:-\?\[-\]\{\}]+)/(?:\*|[^!\"\(\),/:-\?\[-\]\{\}]+)|\*)(?:[\s\x0b]*;[\s\x0b]*(?:charset[\s\x0b]*=[\s\x0b]*\"?(?:iso-8859-15?|utf-8|windows-1252)\b\"?|(?:[^\s\x0b-\"\(\),/:-\?\[-\]c\{\}]|c(?:[^!\"\(\),/:-\?\[-\]h\{\}]|h(?:[^!\"\(\),/:-\?\[-\]a\{\}]|a(?:[^!\"\(\),/:-\?\[-\]r\{\}]|r(?:[^!\"\(\),/:-\?\[-\]s\{\}]|s(?:[^!\"\(\),/:-\?\[-\]e\{\}]|e[^!\"\(\),/:-\?\[-\]t\{\}]))))))[^!\"\(\),/:-\?\[-\]\{\}]*[\s\x0b]*=[\s\x0b]*[^!\(\),/:-\?\[-\]\{\}]+);?)*(?:[\s\x0b]*,[\s\x0b]*(?:(?:\*|[^!\"\(\),/:-\?\[-\]\{\}]+)/(?:\*|[^!\"\(\),/:-\?\[-\]\{\}]+)|\*)(?:[\s\x0b]*;[\s\x0b]*(?:charset[\s\x0b]*=[\s\x0b]*\"?(?:iso-8859-15?|utf-8|windows-1252)\b\"?|(?:[^\s\x0b-\"\(\),/:-\?\[-\]c\{\}]|c(?:[^!\"\(\),/:-\?\[-\]h\{\}]|h(?:[^!\"\(\),/:-\?\[-\]a\{\}]|a(?:[^!\"\(\),/:-\?\[-\]r\{\}]|r(?:[^!\"\(\),/:-\?\[-\]s\{\}]|s(?:[^!\"\(\),/:-\?\[-\]e\{\}]|e[^!\"\(\),/:-\?\[-\]t\{\}]))))))[^!\"\(\),/:-\?\[-\]\{\}]*[\s\x0b]*=[\s\x0b]*[^!\(\),/:-\?\[-\]\{\}]+);?)*)*$" \
@@ -723,7 +723,7 @@ SecRule REQUEST_HEADERS:Accept "!@rx ^(?:(?:\*|[^!\"\(\),/:-\?\[-\]\{\}]+)/(?:\*
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule REQBODY_PROCESSOR "!@streq JSON" \
@@ -740,7 +740,7 @@ SecRule REQBODY_PROCESSOR "!@streq JSON" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/267/72',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     chain"
     SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@rx (?i)\x5cu[0-9a-f]{4}" \
@@ -758,7 +758,7 @@ SecRule REQUEST_URI_RAW "@contains #" \
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule &REQUEST_HEADERS:Content-Type "@gt 1" \
@@ -774,11 +774,11 @@ SecRule &REQUEST_HEADERS:Content-Type "@gt 1" \
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:920013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:920014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:920013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:920014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d+)?-(?:\d+)?\s*,?\s*){6}" \
     "id:920200,\
     phase:1,\
@@ -793,7 +793,7 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_BASENAME "!@endsWith .pdf" \
@@ -812,7 +812,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d+)?-(?:\d+)?\s*,?\s*){63}" \
@@ -831,7 +831,7 @@ SecRule ARGS "@rx %[0-9a-fA-F]{2}" \
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/267/120',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.warning_anomaly_score}'"
 SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 9,10,13,32-126,128-255" \
@@ -848,7 +848,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 9,10,13,
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 SecRule &REQUEST_HEADERS:User-Agent "@eq 0" \
@@ -865,7 +865,7 @@ SecRule &REQUEST_HEADERS:User-Agent "@eq 0" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'NOTICE',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.notice_anomaly_score}'"
 SecRule FILES_NAMES|FILES "@rx ['\";=\x5c]" \
@@ -882,7 +882,7 @@ SecRule FILES_NAMES|FILES "@rx ['\";=\x5c]" \
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
@@ -898,7 +898,7 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     chain"
     SecRule &REQUEST_HEADERS:Content-Type "@eq 0" \
@@ -920,7 +920,7 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.header_name_920451_%{tx.0}=/%{tx.0}/',\
     chain"
@@ -940,15 +940,15 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)application/x-www-form-urlencoded
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/267/72',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_BODY "@rx \x25" \
         "chain"
         SecRule REQUEST_BODY "@validateUrlEncoding" \
             "setvar:'tx.inbound_anomaly_score_pl2=+%{tx.warning_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 32-36,38-126" \
     "id:920272,\
     phase:2,\
@@ -963,7 +963,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteR
     tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 SecRule &REQUEST_HEADERS:Accept "@eq 0" \
@@ -980,7 +980,7 @@ SecRule &REQUEST_HEADERS:Accept "@eq 0" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'NOTICE',\
     chain"
     SecRule REQUEST_METHOD "!@rx ^(?:OPTIONS|CONNECT)$" \
@@ -1001,7 +1001,7 @@ SecRule &REQUEST_HEADERS:x-up-devcap-post-charset "@ge 1" \
     tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     chain"
     SecRule REQUEST_HEADERS:User-Agent "@rx ^(?i)up" \
@@ -1022,7 +1022,7 @@ SecRule &REQUEST_HEADERS:Cache-Control "@gt 0" \
     tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     chain"
     SecRule REQUEST_HEADERS:Cache-Control "!@rx ^(?:(?:max-age=[0-9]+|min-fresh=[0-9]+|no-cache|no-store|no-transform|only-if-cached|max-stale(?:=[0-9]+)?)(?:\s*\,\s*|$)){1,7}$" \
@@ -1042,11 +1042,11 @@ SecRule REQUEST_HEADERS:Accept-Encoding "!@rx br|compress|deflate|(?:pack200-)?g
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:920017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:920018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:920017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:920018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 SecRule REQUEST_BASENAME "@endsWith .pdf" \
     "id:920202,\
     phase:1,\
@@ -1061,7 +1061,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     tag:'paranoia-level/4',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d+)?-(?:\d+)?\s*,?\s*){6}" \
@@ -1080,7 +1080,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 38,44-46,48-58,61,65-90
     tag:'paranoia-level/4',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
 SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!REQUEST_HEADERS:Cookie|!REQUEST_HEADERS:Sec-Fetch-User|!REQUEST_HEADERS:Sec-CH-UA|!REQUEST_HEADERS:Sec-CH-UA-Mobile "@validateByteRange 32,34,38,42-59,61,65-90,95,97-122" \
@@ -1097,7 +1097,7 @@ SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!RE
     tag:'paranoia-level/4',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
 SecRule REQUEST_HEADERS:Sec-Fetch-User|REQUEST_HEADERS:Sec-CH-UA-Mobile "!@rx ^(?:\?[01])?$" \
@@ -1114,7 +1114,7 @@ SecRule REQUEST_HEADERS:Sec-Fetch-User|REQUEST_HEADERS:Sec-CH-UA-Mobile "!@rx ^(
     tag:'paranoia-level/4',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
 SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@rx (?:^|[^\x5c])\x5c[cdeghijklmpqwxyz123456789]" \
@@ -1132,7 +1132,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@rx (?:^|[^\x5c])\x5c[cdegh
     tag:'paranoia-level/4',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/153/267',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl4=+%{tx.critical_anomaly_score}'"

--- a/rules/@owasp_crs/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/@owasp_crs/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -7,8 +7,8 @@
 # Apache Software License (ASL) version 2
 # Please see the enclosed LICENSE file for full details.
 # ------------------------------------------------------------------------
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:921011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:921012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:921011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:921012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 SecRule ARGS_NAMES|ARGS|REQUEST_BODY|XML:/* "@rx (?:get|post|head|options|connect|put|delete|trace|track|patch|propfind|propatch|mkcol|copy|move|lock|unlock)\s+[^\s]+\s+http/\d" \
     "id:921110,\
     phase:2,\
@@ -24,7 +24,7 @@ SecRule ARGS_NAMES|ARGS|REQUEST_BODY|XML:/* "@rx (?:get|post|head|options|connec
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/33',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -43,7 +43,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/34',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -62,7 +62,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/34',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -81,7 +81,7 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@rx [\n\r]" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/273',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -100,7 +100,7 @@ SecRule ARGS_NAMES "@rx [\n\r]" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/33',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -119,7 +119,7 @@ SecRule ARGS_GET_NAMES|ARGS_GET "@rx [\n\r]+(?:\s|location|refresh|(?:set-)?cook
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/33',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -137,7 +137,7 @@ SecRule REQUEST_FILENAME "@rx [\n\r]" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/34',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -155,7 +155,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/136',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule REQUEST_HEADERS:Content-Type "@rx ^[^\s\x0b,;]+[\s\x0b,;].*?(?:application/(?:.+\+)?json|(?:application/(?:soap\+)?|text/)xml)" \
@@ -174,7 +174,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^\s\x0b,;]+[\s\x0b,;].*?(?:applicati
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule REQUEST_URI "@rx unix:[^|]*\|" \
@@ -192,11 +192,11 @@ SecRule REQUEST_URI "@rx unix:[^|]*\|" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/33',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:921013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:921014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:921013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:921014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 SecRule ARGS_GET "@rx [\n\r]" \
     "id:921151,\
     phase:1,\
@@ -212,7 +212,7 @@ SecRule ARGS_GET "@rx [\n\r]" \
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/33',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -232,11 +232,11 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^\s\x0b,;]+[\s\x0b,;].*?\b(?:((?:tex
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:921015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:921016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:921015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:921016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 SecRule &REQUEST_HEADERS:Range "@gt 0" \
     "id:921230,\
     phase:1,\
@@ -251,7 +251,7 @@ SecRule &REQUEST_HEADERS:Range "@gt 0" \
     tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 SecRule ARGS_NAMES "@rx ." \
@@ -265,7 +265,7 @@ SecRule ARGS_NAMES "@rx ." \
     tag:'attack-protocol',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/137/15/460',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'TX.paramcounter_%{MATCHED_VAR_NAME}=+1'"
 SecRule TX:/paramcounter_.*/ "@gt 1" \
     "id:921180,\
@@ -280,7 +280,7 @@ SecRule TX:/paramcounter_.*/ "@gt 1" \
     tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/137/15/460',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -298,12 +298,12 @@ SecRule ARGS_NAMES "@rx (][^\]]+$|][^\]]+\[)" \
     tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/137/15/460',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:921017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:921018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:921017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:921018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 SecRule ARGS_NAMES "@rx \[" \
     "id:921220,\
     phase:2,\
@@ -318,7 +318,7 @@ SecRule ARGS_NAMES "@rx \[" \
     tag:'paranoia-level/4',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/137/15/460',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl4=+%{tx.critical_anomaly_score}'"

--- a/rules/@owasp_crs/REQUEST-922-MULTIPART-ATTACK.conf
+++ b/rules/@owasp_crs/REQUEST-922-MULTIPART-ATTACK.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -21,7 +21,7 @@ SecRule &MULTIPART_PART_HEADERS:_charset_ "!@eq 0" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.922100_charset=|%{ARGS._charset_}|',\
     chain"
@@ -43,7 +43,7 @@ SecRule MULTIPART_PART_HEADERS "@rx ^content-type\s*:\s*(.*)$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/272/220',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     chain"
     SecRule TX:1 "!@rx ^(?:(?:\*|[^!\"\(\),/:-\?\[-\]\{\}]+)/(?:\*|[^!\"\(\),/:-\?\[-\]\{\}]+)|\*)(?:[\s\x0b]*;[\s\x0b]*(?:charset[\s\x0b]*=[\s\x0b]*\"?(?:iso-8859-15?|utf-8|windows-1252)\b\"?|(?:[^\s\x0b-\"\(\),/:-\?\[-\]c\{\}]|c(?:[^!\"\(\),/:-\?\[-\]h\{\}]|h(?:[^!\"\(\),/:-\?\[-\]a\{\}]|a(?:[^!\"\(\),/:-\?\[-\]r\{\}]|r(?:[^!\"\(\),/:-\?\[-\]s\{\}]|s(?:[^!\"\(\),/:-\?\[-\]e\{\}]|e[^!\"\(\),/:-\?\[-\]t\{\}]))))))[^!\"\(\),/:-\?\[-\]\{\}]*[\s\x0b]*=[\s\x0b]*[^!\(\),/:-\?\[-\]\{\}]+);?)*(?:[\s\x0b]*,[\s\x0b]*(?:(?:\*|[^!\"\(\),/:-\?\[-\]\{\}]+)/(?:\*|[^!\"\(\),/:-\?\[-\]\{\}]+)|\*)(?:[\s\x0b]*;[\s\x0b]*(?:charset[\s\x0b]*=[\s\x0b]*\"?(?:iso-8859-15?|utf-8|windows-1252)\b\"?|(?:[^\s\x0b-\"\(\),/:-\?\[-\]c\{\}]|c(?:[^!\"\(\),/:-\?\[-\]h\{\}]|h(?:[^!\"\(\),/:-\?\[-\]a\{\}]|a(?:[^!\"\(\),/:-\?\[-\]r\{\}]|r(?:[^!\"\(\),/:-\?\[-\]s\{\}]|s(?:[^!\"\(\),/:-\?\[-\]e\{\}]|e[^!\"\(\),/:-\?\[-\]t\{\}]))))))[^!\"\(\),/:-\?\[-\]\{\}]*[\s\x0b]*=[\s\x0b]*[^!\(\),/:-\?\[-\]\{\}]+);?)*)*$" \
@@ -63,7 +63,7 @@ SecRule MULTIPART_PART_HEADERS "@rx content-transfer-encoding:(.*)" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/272/220',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule MULTIPART_PART_HEADERS "@rx [^\x21-\x7E][\x21-\x39\x3B-\x7E]*:" \
@@ -81,6 +81,6 @@ SecRule MULTIPART_PART_HEADERS "@rx [^\x21-\x7E][\x21-\x39\x3B-\x7E]*:" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/272/220',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"

--- a/rules/@owasp_crs/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/@owasp_crs/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -7,8 +7,8 @@
 # Apache Software License (ASL) version 2
 # Please see the enclosed LICENSE file for full details.
 # ------------------------------------------------------------------------
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:930011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:930012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:930011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:930012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
 SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|FILES|XML:/* "@rx (?i)(?:[/\x5c]|%(?:2(?:f|5(?:2f|5c|c(?:1%259c|0%25af))|%46)|5c|c(?:0%(?:[2aq]f|5c|9v)|1%(?:[19p]c|8s|af))|(?:bg%q|(?:e|f(?:8%8)?0%8)0%80%a)f|u(?:221[56]|EFC8|F025|002f)|%3(?:2(?:%(?:%6|4)6|F)|5%%63)|1u)|0x(?:2f|5c))(?:\.(?:%0[01]|\?)?|\?\.?|%(?:2(?:(?:5(?:2|c0%25a))?e|%45)|c0(?:\.|%[256aef]e)|u(?:(?:ff0|002)e|2024)|%32(?:%(?:%6|4)5|E)|(?:e|f(?:(?:8|c%80)%8)?0%8)0%80%ae)|0x2e){2,3}(?:[/\x5c]|%(?:2(?:f|5(?:2f|5c|c(?:1%259c|0%25af))|%46)|5c|c(?:0%(?:[2aq]f|5c|9v)|1%(?:[19p]c|8s|af))|(?:bg%q|(?:e|f(?:8%8)?0%8)0%80%a)f|u(?:221[56]|EFC8|F025|002f)|%3(?:2(?:%(?:%6|4)6|F)|5%%63)|1u)|0x(?:2f|5c))" \
     "id:930100,\
     phase:2,\
@@ -24,7 +24,7 @@ SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|FILES|XML:
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/126',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}'"
@@ -43,7 +43,7 @@ SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|FILES|XML:/* "
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/126',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
@@ -64,7 +64,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/126',\
     tag:'PCI/6.5.4',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -84,12 +84,12 @@ SecRule REQUEST_FILENAME "@pmFromFile restricted-files.data" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/126',\
     tag:'PCI/6.5.4',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:930013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:930014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:930013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:930014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
 SecRule REQUEST_HEADERS:Referer|REQUEST_HEADERS:User-Agent "@pmFromFile lfi-os-files.data" \
     "id:930121,\
     phase:1,\
@@ -106,12 +106,12 @@ SecRule REQUEST_HEADERS:Referer|REQUEST_HEADERS:User-Agent "@pmFromFile lfi-os-f
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/126',\
     tag:'PCI/6.5.4',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:930015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:930016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:930017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:930018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:930015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:930016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:930017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:930018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
 SecMarker "END-REQUEST-930-APPLICATION-ATTACK-LFI"

--- a/rules/@owasp_crs/REQUEST-931-APPLICATION-ATTACK-RFI.conf
+++ b/rules/@owasp_crs/REQUEST-931-APPLICATION-ATTACK-RFI.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -7,8 +7,8 @@
 # Apache Software License (ASL) version 2
 # Please see the enclosed LICENSE file for full details.
 # ------------------------------------------------------------------------
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:931011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:931012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:931011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:931012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
 SecRule ARGS "@rx ^(?i:file|ftps?|https?)://(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})" \
     "id:931100,\
     phase:2,\
@@ -24,7 +24,7 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?)://(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/175/253',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -43,7 +43,7 @@ SecRule QUERY_STRING|REQUEST_BODY "@rx (?i)(?:\binclude\s*\([^)]*|mosConfig_abso
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/175/253',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -62,12 +62,12 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?).*?\?+$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/175/253',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:931013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:931014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:931013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:931014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
 SecRule ARGS "@rx (?i)(?:(?:url|jar):)?(?:a(?:cap|f[ps]|ttachment)|b(?:eshare|itcoin|lob)|c(?:a(?:llto|p)|id|vs|ompress.(?:zlib|bzip2))|d(?:a(?:v|ta)|ict|n(?:s|tp))|e(?:d2k|xpect)|f(?:(?:ee)?d|i(?:le|nger|sh)|tps?)|g(?:it|o(?:pher)?|lob)|h(?:323|ttps?)|i(?:ax|cap|(?:ma|p)ps?|rc[6s]?)|ja(?:bbe)?r|l(?:dap[is]?|ocal_file)|m(?:a(?:ilto|ven)|ms|umble)|n(?:e(?:tdoc|ws)|fs|ntps?)|ogg|p(?:aparazzi|h(?:ar|p)|op(?:2|3s?)|r(?:es|oxy)|syc)|r(?:mi|sync|tm(?:f?p)?|ar)|s(?:3|ftp|ips?|m(?:[bs]|tps?)|n(?:ews|mp)|sh(?:2(?:.(?:s(?:hell|(?:ft|c)p)|exec|tunnel))?)?|vn(?:\+ssh)?)|t(?:e(?:amspeak|lnet)|ftp|urns?)|u(?:dp|nreal|t2004)|v(?:entrilo|iew-source|nc)|w(?:ebcal|ss?)|x(?:mpp|ri)|zip)://(?:[^@]+@)?([^/]*)" \
     "id:931130,\
     phase:2,\
@@ -83,7 +83,7 @@ SecRule ARGS "@rx (?i)(?:(?:url|jar):)?(?:a(?:cap|f[ps]|ttachment)|b(?:eshare|it
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/175/253',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_parameter_%{MATCHED_VAR_NAME}=.%{tx.1}',\
     chain"
@@ -105,15 +105,15 @@ SecRule REQUEST_FILENAME "@rx (?i)(?:(?:url|jar):)?(?:a(?:cap|f[ps]|ttachment)|b
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/175/253',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_parameter_%{MATCHED_VAR_NAME}=.%{tx.1}',\
     chain"
     SecRule TX:/rfi_parameter_.*/ "!@endsWith .%{request_headers.host}" \
         "setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:931015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:931016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:931017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:931018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:931015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:931016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:931017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:931018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
 SecMarker "END-REQUEST-931-APPLICATION-ATTACK-RFI"

--- a/rules/@owasp_crs/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/@owasp_crs/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -7,8 +7,8 @@
 # Apache Software License (ASL) version 2
 # Please see the enclosed LICENSE file for full details.
 # ------------------------------------------------------------------------
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:932011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:932012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:932011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:932012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:b[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?u[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?s[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?y[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?b[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?o[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?x|c[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?o[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?m[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?m[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?a[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?n[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?d|e[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?(?:n[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?v|v[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?a[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?l)|[ls][\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?t[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?r[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?a[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?c[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?e|n[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?o[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?h[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?u[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?p|t[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?i[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?m[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?e(?:[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?o[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?u[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?t)?|w[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?a[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?t[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?c[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?h|[\n\r;=`\{]|\|\|?|&&?|\$(?:\(\(?|[\[\{])|<(?:\(|<<)|>\(|\([\s\x0b]*\))[\s\x0b]*(?:[\$\{]|(?:[\s\x0b]*\(|!)[\s\x0b]*|[0-9A-Z_a-z]+=(?:[^\s\x0b]*|\$(?:.*|.*)|[<>].*|'.*'|\".*\")[\s\x0b]+)*[\s\x0b]*[\"']*(?:[\"'-\+\--9\?A-\]_a-z\|]+/)?[\"'\x5c]*(?:7[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?z(?:[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?[arx])?|(?:(?:b[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?z|x)[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?z|h[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?u[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?p)[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?[\s\x0b&\),<>\|].*|[ckz][\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?s[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?h|d[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?f|e[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?(?:n[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?v[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?[\s\x0b&\),<>\|].*|s[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?h)|f[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?[dg]|g[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?(?:c[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?c[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?(?:[&,<>\|]|(?:[\-\.0-9A-Z_a-z][\"'\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\*\-0-9\?@_a-\{]*)?\x5c?)+[\s\x0b&,<>\|]).*|p[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?g)|i[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?r[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?b|l[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?(?:s|z[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?(?:4|[\s\x0b&\),<>\|].*))|p[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?(?:(?:g|h[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?p)[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?[\s\x0b&\),<>\|].*|w[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?d|x[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?z)|r[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?c(?:[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?p[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?[\s\x0b&\),<>\|].*)?|s[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?(?:c[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?p|(?:e[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?d|(?:s[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?)?h)[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?[\s\x0b&\),<>\|].*|v[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?n)|u[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?d[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?p|w[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?3[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?m)\b" \
     "id:932230,\
     phase:2,\
@@ -25,7 +25,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -45,7 +45,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -66,7 +66,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -86,7 +86,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -106,7 +106,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -126,7 +126,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -145,7 +145,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -165,7 +165,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -185,7 +185,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -205,7 +205,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -225,7 +225,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -245,7 +245,7 @@ SecRule REQUEST_HEADERS|REQUEST_LINE "@rx ^\(\s*\)\s+{" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -265,7 +265,7 @@ SecRule ARGS_NAMES|ARGS|FILES_NAMES "@rx ^\(\s*\)\s+{" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -285,7 +285,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -305,7 +305,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -325,7 +325,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -345,12 +345,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:932013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:932014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:932013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:932014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:b[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?u[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?s[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?y[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?b[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?o[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?x|c[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?o[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?m[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?m[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?a[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?n[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?d|e[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?(?:n[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?v|v[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?a[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?l)|[ls][\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?t[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?r[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?a[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?c[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?e|n[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?o[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?h[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?u[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?p|t[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?i[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?m[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?e(?:[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?o[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?u[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?t)?|w[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?a[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?t[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?c[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?h|[\n\r;=`\{]|\|\|?|&&?|\$(?:\(\(?|[\[\{])|<(?:\(|<<)|>\(|\([\s\x0b]*\))[\s\x0b]*(?:[\$\{]|(?:[\s\x0b]*\(|!)[\s\x0b]*|[0-9A-Z_a-z]+=(?:[^\s\x0b]*|\$(?:.*|.*)|[<>].*|'.*'|\".*\")[\s\x0b]+)*[\s\x0b]*[\"']*(?:[\"'-\+\--9\?A-\]_a-z\|]+/)?[\"'\x5c]*\.[\s\x0b].*\b" \
     "id:932231,\
     phase:2,\
@@ -367,7 +367,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -387,7 +387,7 @@ SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@rx \$(?:\((?:.*|\(.
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -407,7 +407,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.932200_matched_var_name=%{matched_var_name}',\
     chain"
@@ -434,7 +434,7 @@ SecRule REQUEST_HEADERS:Referer "@rx ^[^#]+" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.932205_matched_var_name=%{matched_var_name}',\
     chain"
@@ -465,7 +465,7 @@ SecRule REQUEST_HEADERS:Referer "@rx ^[^\.]*?(?:['\*\?\x5c`][^\n/]+/|/[^/]+?['\*
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.932206_matched_var_name=%{matched_var_name}',\
     chain"
@@ -492,7 +492,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -512,7 +512,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS|XML:
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.932240_matched_var_name=%{matched_var_name}',\
     chain"
@@ -535,7 +535,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -554,7 +554,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/137/134',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -572,7 +572,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/137/134',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -590,7 +590,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/137/134',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -610,7 +610,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -630,7 +630,7 @@ SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@rx (?i)(?:^|b[\"'\)
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -650,12 +650,12 @@ SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@pmFromFile unix-she
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:932015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:932016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:932015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:932016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:b[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?u[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?s[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?y[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?b[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?o[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?x|c[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?o[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?m[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?m[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?a[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?n[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?d|e[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?(?:n[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?v|v[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?a[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?l)|[ls][\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?t[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?r[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?a[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?c[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?e|n[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?o[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?h[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?u[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?p|t[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?i[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?m[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?e(?:[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?o[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?u[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?t)?|w[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?a[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?t[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?c[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?h|[\n\r;=`\{]|\|\|?|&&?|\$(?:\(\(?|[\[\{])|<(?:\(|<<)|>\(|\([\s\x0b]*\))[\s\x0b]*(?:[\$\{]|(?:[\s\x0b]*\(|!)[\s\x0b]*|[0-9A-Z_a-z]+=(?:[^\s\x0b]*|\$(?:.*|.*)|[<>].*|'.*'|\".*\")[\s\x0b]+)*[\s\x0b]*[\"']*(?:[\"'-\+\--9\?A-\]_a-z\|]+/)?[\"'\x5c]*(?:(?:(?:a[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?p[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?t[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?i[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?t[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?u[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?d|u[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?p[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?2[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?d[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?a[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?t)[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?e|v[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?i)[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?[\s\x0b&\),<>\|].*|d[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?n[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?f|p[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?(?:a[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?c[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?m[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?a[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?n[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?[\s\x0b&\),<>\|].*|s)|w[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?(?:h[\"'\)\[\x5c]*(?:(?:(?:\|\||&&)[\s\x0b]*)?\$[!#\(\*\-0-9\?@_a-\{]*)?\x5c?o|[\s\x0b&\),<>\|].*))\b" \
     "id:932232,\
     phase:2,\
@@ -672,7 +672,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -692,7 +692,7 @@ SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@rx (?i)\b(?:7z[arx]
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -712,7 +712,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -732,7 +732,7 @@ SecRule ARGS "@rx /(?:[?*]+[a-z/]+|[a-z/]+[?*]+)" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -750,7 +750,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/137/134',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -768,7 +768,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/137/134',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -786,7 +786,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/137/134',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -805,10 +805,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:932017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:932018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:932017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:932018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 SecMarker "END-REQUEST-932-APPLICATION-ATTACK-RCE"

--- a/rules/@owasp_crs/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/@owasp_crs/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -7,8 +7,8 @@
 # Apache Software License (ASL) version 2
 # Please see the enclosed LICENSE file for full details.
 # ------------------------------------------------------------------------
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:933011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:933012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:933011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:933012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)<\?(?:[^x]|x(?:[^m]|m(?:[^l]|l(?:[^\s\x0b]|[\s\x0b]+[^a-z]|$)))|$|php)|\[[/\x5c]?php\]" \
     "id:933100,\
     phase:2,\
@@ -24,7 +24,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -43,7 +43,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -62,7 +62,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.933120_matched_var=%{MATCHED_VAR}',\
     setvar:'tx.933120_matched_var_name=%{MATCHED_VAR_NAME}',\
@@ -88,9 +88,28 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@rx \$\s*\{\s*\S[^\{\}]*\}" \
+    "id:933135,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'PHP Injection Attack: Variable Access Found',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-injection-php',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/242',\
+    ver:'OWASP_CRS/4.10.0',\
+    severity:'CRITICAL',\
+    setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)php://(?:std(?:in|out|err)|(?:in|out)put|fd|memory|temp|filter)" \
     "id:933140,\
@@ -107,7 +126,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -125,7 +144,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -144,7 +163,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -163,7 +182,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -182,7 +201,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -201,7 +220,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -220,12 +239,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:933013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:933014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:933013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:933014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@pmFromFile php-function-names-933151.data" \
     "id:933151,\
     phase:2,\
@@ -241,7 +260,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.933151_matched_var=%{MATCHED_VAR}',\
     setvar:'tx.933151_matched_var_name=%{MATCHED_VAR_NAME}',\
@@ -252,8 +271,8 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
         SecRule TX:1 "@pmFromFile php-function-names-933151.data" \
             "setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
             setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:933015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:933016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:933015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:933016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx AUTH_TYPE|HTTP_(?:ACCEPT(?:_(?:CHARSET|ENCODING|LANGUAGE))?|CONNECTION|(?:HOS|USER_AGEN)T|KEEP_ALIVE|(?:REFERE|X_FORWARDED_FO)R)|ORIG_PATH_INFO|PATH_(?:INFO|TRANSLATED)|QUERY_STRING|REQUEST_URI" \
     "id:933131,\
     phase:2,\
@@ -269,7 +288,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -288,7 +307,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -307,7 +326,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -326,7 +345,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -345,10 +364,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:933017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:933018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:933017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:933018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
 SecMarker "END-REQUEST-933-APPLICATION-ATTACK-PHP"

--- a/rules/@owasp_crs/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
+++ b/rules/@owasp_crs/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -7,8 +7,8 @@
 # Apache Software License (ASL) version 2
 # Please see the enclosed LICENSE file for full details.
 # ------------------------------------------------------------------------
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:934011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:934012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:934011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:934012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
 SecRule REQUEST_FILENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx _(?:\$\$ND_FUNC\$\$_|_js_function)|(?:\beval|new[\s\x0b]+Function[\s\x0b]*)\(|String\.fromCharCode|function\(\)\{|this\.constructor|module\.exports=|\([\s\x0b]*[^0-9A-Z_a-z]child_process[^0-9A-Z_a-z][\s\x0b]*\)|process(?:\.(?:(?:a(?:ccess|ppendfile|rgv|vailability)|c(?:aveats|h(?:mod|own)|(?:los|opyfil)e|p|reate(?:read|write)stream)|ex(?:ec(?:file)?|ists)|f(?:ch(?:mod|own)|data(?:sync)?|s(?:tat|ync)|utimes)|inodes|l(?:chmod|ink|stat|utimes)|mkd(?:ir|temp)|open(?:dir)?|r(?:e(?:ad(?:dir|file|link|v)?|name)|m)|s(?:pawn(?:file)?|tat|ymlink)|truncate|u(?:n(?:link|watchfile)|times)|w(?:atchfile|rite(?:file|v)?))(?:sync)?(?:\.call)?\(|binding|constructor|env|global|main(?:Module)?|process|require)|\[[\"'`](?:(?:a(?:ccess|ppendfile|rgv|vailability)|c(?:aveats|h(?:mod|own)|(?:los|opyfil)e|p|reate(?:read|write)stream)|ex(?:ec(?:file)?|ists)|f(?:ch(?:mod|own)|data(?:sync)?|s(?:tat|ync)|utimes)|inodes|l(?:chmod|ink|stat|utimes)|mkd(?:ir|temp)|open(?:dir)?|r(?:e(?:ad(?:dir|file|link|v)?|name)|m)|s(?:pawn(?:file)?|tat|ymlink)|truncate|u(?:n(?:link|watchfile)|times)|w(?:atchfile|rite(?:file|v)?))(?:sync)?|binding|constructor|env|global|main(?:Module)?|process|require)[\"'`]\])|(?:binding|constructor|env|global|main(?:Module)?|process|require)\[|console(?:\.(?:debug|error|info|trace|warn)(?:\.call)?\(|\[[\"'`](?:debug|error|info|trace|warn)[\"'`]\])|require(?:\.(?:resolve(?:\.call)?\(|main|extensions|cache)|\[[\"'`](?:(?:resolv|cach)e|main|extensions)[\"'`]\])" \
     "id:934100,\
     phase:2,\
@@ -25,7 +25,7 @@ SecRule REQUEST_FILENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIE
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
@@ -45,7 +45,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/664',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -65,7 +65,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1/180/77',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
@@ -86,7 +86,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -106,7 +106,7 @@ SecRule REQUEST_FILENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIE
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
@@ -126,12 +126,12 @@ SecRule REQUEST_FILENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIE
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:934013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:934014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:934013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:934014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
 SecRule REQUEST_FILENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:close|exists|fork|(?:ope|spaw)n|re(?:ad|quire)|w(?:atch|rite))[\s\x0b]*\(" \
     "id:934101,\
     phase:2,\
@@ -148,7 +148,7 @@ SecRule REQUEST_FILENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIE
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
@@ -168,7 +168,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/664',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -188,12 +188,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:934015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:934016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:934017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:934018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:934015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:934016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:934017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:934018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
 SecMarker "END-REQUEST-934-APPLICATION-ATTACK-GENERIC"

--- a/rules/@owasp_crs/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/@owasp_crs/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -7,8 +7,8 @@
 # Apache Software License (ASL) version 2
 # Please see the enclosed LICENSE file for full details.
 # ------------------------------------------------------------------------
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:941011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:941012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:941011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:941012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
 SecRule REQUEST_FILENAME "!@validateByteRange 20, 45-47, 48-57, 65-90, 95, 97-122" \
     "id:941010,\
     phase:1,\
@@ -17,7 +17,7 @@ SecRule REQUEST_FILENAME "!@validateByteRange 20, 45-47, 48-57, 65-90, 95, 97-12
     nolog,\
     tag:'OWASP_CRS',\
     ctl:ruleRemoveTargetByTag=xss-perf-disable;REQUEST_FILENAME,\
-    ver:'OWASP_CRS/4.9.0'"
+    ver:'OWASP_CRS/4.10.0'"
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|XML:/* "@detectXSS" \
     "id:941100,\
     phase:2,\
@@ -33,7 +33,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -53,11 +53,11 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@rx (?i).(?:\b(?:x(?:link:href|html|mlns)|data:text/html|formaction|pattern\b.*?=)|!ENTITY[\s\x0b]+(?:%[\s\x0b]+)?[^\s\x0b]+[\s\x0b]+(?:SYSTEM|PUBLIC)|@import|;base64)\b" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@rx (?i).(?:\b(?:(?:x(?:link:href|html|mlns)|data:text/html|formaction)\b|pattern[\s\x0b]*=)|(?:!ENTITY[\s\x0b]+(?:%[\s\x0b]+)?[^\s\x0b]+[\s\x0b]+(?:SYSTEM|PUBLIC)|@import|;base64)\b)" \
     "id:941130,\
     phase:2,\
     block,\
@@ -73,7 +73,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -93,7 +93,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -113,7 +113,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -133,7 +133,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -153,7 +153,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -173,7 +173,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -193,7 +193,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -213,7 +213,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -233,7 +233,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -253,7 +253,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -273,7 +273,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -293,7 +293,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -313,7 +313,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -333,7 +333,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -353,7 +353,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -373,7 +373,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -393,7 +393,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -413,7 +413,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VARS "@rx (?:\xbc\s*/\s*[^\xbe>]*[\xbe>])|(?:<\s*/\s*[^\xbe]*\xbe)" \
@@ -435,7 +435,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -454,7 +454,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242/63',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -473,7 +473,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS|REQU
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242/63',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -492,7 +492,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -511,12 +511,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:941013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:941014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:941013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:941014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
 SecRule REQUEST_FILENAME|REQUEST_HEADERS:Referer "@detectXSS" \
     "id:941101,\
     phase:1,\
@@ -533,7 +533,7 @@ SecRule REQUEST_FILENAME|REQUEST_HEADERS:Referer "@detectXSS" \
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -553,7 +553,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -573,7 +573,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -593,7 +593,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -614,7 +614,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242/63',\
     tag:'PCI/6.5.1',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -635,7 +635,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     tag:'PCI/6.5.1',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -656,7 +656,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     tag:'PCI/6.5.1',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -675,12 +675,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242/63',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:941015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:941016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:941017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:941018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:941015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:941016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:941017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:941018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
 SecMarker "END-REQUEST-941-APPLICATION-ATTACK-XSS"

--- a/rules/@owasp_crs/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/@owasp_crs/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -7,8 +7,8 @@
 # Apache Software License (ASL) version 2
 # Please see the enclosed LICENSE file for full details.
 # ------------------------------------------------------------------------
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:942011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:942012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:942011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:942012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@detectSQLi" \
     "id:942100,\
     phase:2,\
@@ -25,7 +25,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
@@ -46,7 +46,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -66,7 +66,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -86,7 +86,7 @@ SecRule REQUEST_FILENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIE
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -106,7 +106,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -126,7 +126,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -146,7 +146,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -166,7 +166,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -186,7 +186,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -206,7 +206,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -226,7 +226,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -246,7 +246,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -266,7 +266,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -286,7 +286,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -306,7 +306,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -326,7 +326,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -346,7 +346,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -367,7 +367,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -386,7 +386,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -405,12 +405,12 @@ SecRule REQUEST_FILENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIE
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:942013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:942014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:942013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:942014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
 SecRule ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@rx (?i)[!=]=|&&|\|\||->|>[=>]|<(?:[<=]|>(?:[\s\x0b]+binary)?)|\b(?:(?:xor|r(?:egexp|like)|i(?:snull|like)|notnull)\b|collate(?:[^0-9A-Z_a-z]*?(?:U&)?[\"'`]|[^0-9A-Z_a-z]+(?:(?:binary|nocase|rtrim)\b|[0-9A-Z_a-z]*?_))|(?:likel(?:ihood|y)|unlikely)[\s\x0b]*\()|r(?:egexp|like)[\s\x0b]+binary|not[\s\x0b]+between[\s\x0b]+(?:0[\s\x0b]+and|(?:'[^']*'|\"[^\"]*\")[\s\x0b]+and[\s\x0b]+(?:'[^']*'|\"[^\"]*\"))|is[\s\x0b]+null|like[\s\x0b]+(?:null|[0-9A-Z_a-z]+[\s\x0b]+escape\b)|(?:^|[^0-9A-Z_a-z])in[\s\x0b\+]*\([\s\x0b\"0-9]+[^\(\)]*\)|[!<->][\s\x0b]*all\b" \
     "id:942120,\
     phase:2,\
@@ -427,7 +427,7 @@ SecRule ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@rx (?i)[!=]=|&&|\|\||->|>[=>]|
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -447,7 +447,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\x0b\"'-\)`]*?\b([0-9A-Z_a-z]+)\b[\s\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.942130_matched_var_name=%{matched_var_name}',\
     chain"
@@ -471,7 +471,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\x0b\"'-\)`]*?\b([0-9A-Z_a-z]+)\b[\s\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.942131_matched_var_name=%{matched_var_name}',\
@@ -496,7 +496,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -516,7 +516,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -536,7 +536,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -556,7 +556,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -576,7 +576,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -596,7 +596,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -616,7 +616,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -636,7 +636,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -656,7 +656,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -676,7 +676,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -696,7 +696,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -716,7 +716,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -736,7 +736,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -756,7 +756,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -776,7 +776,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -796,7 +796,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -816,7 +816,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -836,7 +836,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -856,7 +856,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'´�
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"
@@ -868,7 +868,7 @@ SecRule ARGS_GET:fbclid "@rx [a-zA-Z0-9_-]{61,61}" \
     nolog,\
     tag:'OWASP_CRS',\
     ctl:ruleRemoveTargetById=942440;ARGS:fbclid,\
-    ver:'OWASP_CRS/4.9.0'"
+    ver:'OWASP_CRS/4.10.0'"
 SecRule ARGS_GET:gclid "@rx [a-zA-Z0-9_-]{91,91}" \
     "id:942442,\
     phase:2,\
@@ -877,7 +877,7 @@ SecRule ARGS_GET:gclid "@rx [a-zA-Z0-9_-]{91,91}" \
     nolog,\
     tag:'OWASP_CRS',\
     ctl:ruleRemoveTargetById=942440;ARGS:gclid,\
-    ver:'OWASP_CRS/4.9.0'"
+    ver:'OWASP_CRS/4.10.0'"
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx /\*!?|\*/|[';]--|--(?:[\s\x0b]|[^\-]*?-)|[^&\-]#.*?[\s\x0b]|;?\x00" \
     "id:942440,\
     phase:2,\
@@ -894,7 +894,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VARS "!@rx ^ey[\-0-9A-Z_a-z]+\.ey[\-0-9A-Z_a-z]+\.[\-0-9A-Z_a-z]+$" \
@@ -917,7 +917,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -937,7 +937,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -957,7 +957,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -977,7 +977,7 @@ SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.942521_matched_var_name=%{matched_var_name}',\
     chain"
@@ -1001,7 +1001,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ^.*?\x5c['\"`](?:.*?['\"`])?\s*(?:and|or)\b"
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1021,7 +1021,7 @@ SecRule REQUEST_BASENAME|REQUEST_FILENAME "@detectSQLi" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1041,7 +1041,7 @@ SecRule REQUEST_HEADERS:Referer|REQUEST_HEADERS:User-Agent "@rx (?i)\b(?:a(?:dd(
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1061,12 +1061,12 @@ SecRule REQUEST_HEADERS:Referer|REQUEST_HEADERS:User-Agent "@rx (?i)create[\s\x0
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:942015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:942016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:942015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:942016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\W+\d*?\s*?\bhaving\b\s*?[^\s\-]" \
     "id:942251,\
     phase:2,\
@@ -1083,7 +1083,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -1103,7 +1103,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -1123,7 +1123,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"
@@ -1143,7 +1143,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'´�
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"
@@ -1163,7 +1163,7 @@ SecRule ARGS "@rx \W{4}" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'WARNING',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.warning_anomaly_score}'"
@@ -1183,7 +1183,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -1203,12 +1203,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:942017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:942018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:942017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:942018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'´’‘`<>][^~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'´’‘`<>]*?){3})" \
     "id:942421,\
     phase:1,\
@@ -1225,7 +1225,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl4=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"
@@ -1245,7 +1245,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'´�
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl4=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"

--- a/rules/@owasp_crs/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+++ b/rules/@owasp_crs/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -7,8 +7,8 @@
 # Apache Software License (ASL) version 2
 # Please see the enclosed LICENSE file for full details.
 # ------------------------------------------------------------------------
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:943011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:943012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:943011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:943012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:\.cookie\b.*?;\W*?(?:expires|domain)\W*?=|\bhttp-equiv\W+set-cookie\b)" \
     "id:943100,\
     phase:2,\
@@ -24,7 +24,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/21/593/61',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.session_fixation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -43,7 +43,7 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/21/593/61',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.943110_matched_var_name=%{matched_var_name}',\
     chain"
@@ -68,17 +68,17 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/21/593/61',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.943120_matched_var_name=%{matched_var_name}',\
     chain"
     SecRule &REQUEST_HEADERS:Referer "@eq 0" \
         "setvar:'tx.session_fixation_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:943013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:943014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:943015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:943016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:943017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:943018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:943013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:943014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:943015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:943016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:943017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:943018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
 SecMarker "END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"

--- a/rules/@owasp_crs/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/@owasp_crs/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -7,8 +7,8 @@
 # Apache Software License (ASL) version 2
 # Please see the enclosed LICENSE file for full details.
 # ------------------------------------------------------------------------
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:944011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:944012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:944011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:944012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
 SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \
     "@rx java\.lang\.(?:runtime|processbuilder)" \
     "id:944100,\
@@ -25,7 +25,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/137/6',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -44,7 +44,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VARS|XML:/*|XML://@* "@rx (?i)(?:unmarshaller|base64data|java\.)" \
@@ -66,7 +66,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VARS "@rx (?:runtime|processbuilder)" \
@@ -88,7 +88,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -107,7 +107,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -126,12 +126,12 @@ SecRule REQUEST_LINE|ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUE
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/137/6',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:944013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:944014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:944013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:944014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
 SecRule REQUEST_LINE|ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_HEADERS|XML:/*|XML://@* "@rx (?i)(?:\$|&dollar;?)(?:\{|&l(?:brace|cub);?)(?:[^\}]*(?:\$|&dollar;?)(?:\{|&l(?:brace|cub);?)|jndi|ctx)" \
     "id:944151,\
     phase:2,\
@@ -147,7 +147,7 @@ SecRule REQUEST_LINE|ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUE
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/137/6',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -166,7 +166,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -185,7 +185,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -205,7 +205,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -225,7 +225,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -245,12 +245,12 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:944015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:944016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:944015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:944016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
 SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \
     "@rx (?:cnVudGltZQ|HJ1bnRpbWU|BydW50aW1l|cHJvY2Vzc2J1aWxkZXI|HByb2Nlc3NidWlsZGVy|Bwcm9jZXNzYnVpbGRlcg|Y2xvbmV0cmFuc2Zvcm1lcg|GNsb25ldHJhbnNmb3JtZXI|BjbG9uZXRyYW5zZm9ybWVy|Zm9yY2xvc3VyZQ|GZvcmNsb3N1cmU|Bmb3JjbG9zdXJl|aW5zdGFudGlhdGVmYWN0b3J5|Gluc3RhbnRpYXRlZmFjdG9yeQ|BpbnN0YW50aWF0ZWZhY3Rvcnk|aW5zdGFudGlhdGV0cmFuc2Zvcm1lcg|Gluc3RhbnRpYXRldHJhbnNmb3JtZXI|BpbnN0YW50aWF0ZXRyYW5zZm9ybWVy|aW52b2tlcnRyYW5zZm9ybWVy|Gludm9rZXJ0cmFuc2Zvcm1lcg|BpbnZva2VydHJhbnNmb3JtZXI|cHJvdG90eXBlY2xvbmVmYWN0b3J5|HByb3RvdHlwZWNsb25lZmFjdG9yeQ|Bwcm90b3R5cGVjbG9uZWZhY3Rvcnk|cHJvdG90eXBlc2VyaWFsaXphdGlvbmZhY3Rvcnk|HByb3RvdHlwZXNlcmlhbGl6YXRpb25mYWN0b3J5|Bwcm90b3R5cGVzZXJpYWxpemF0aW9uZmFjdG9yeQ|d2hpbGVjbG9zdXJl|HdoaWxlY2xvc3VyZQ|B3aGlsZWNsb3N1cmU)" \
     "id:944300,\
@@ -267,12 +267,12 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:944017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:944018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:944017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:944018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
 SecRule REQUEST_LINE|ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_HEADERS|XML:/*|XML://@* "@rx (?i)(?:\$|&dollar;?)(?:\{|&l(?:brace|cub);?)" \
     "id:944152,\
     phase:2,\
@@ -288,7 +288,7 @@ SecRule REQUEST_LINE|ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUE
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/137/6',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl4=+%{tx.critical_anomaly_score}'"

--- a/rules/@owasp_crs/REQUEST-949-BLOCKING-EVALUATION.conf
+++ b/rules/@owasp_crs/REQUEST-949-BLOCKING-EVALUATION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -14,7 +14,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 1" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl1}'"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
     "id:949152,\
@@ -23,7 +23,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl1}'"
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
     "id:949053,\
@@ -32,7 +32,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl2}'"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
     "id:949153,\
@@ -41,7 +41,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl2}'"
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
     "id:949054,\
@@ -50,7 +50,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl3}'"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
     "id:949154,\
@@ -59,7 +59,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl3}'"
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
     "id:949055,\
@@ -68,7 +68,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl4}'"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
     "id:949155,\
@@ -77,7 +77,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl4}'"
 SecAction \
     "id:949059,\
@@ -86,7 +86,7 @@ SecAction \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.blocking_inbound_anomaly_score=0'"
 SecAction \
     "id:949159,\
@@ -95,7 +95,7 @@ SecAction \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.detection_inbound_anomaly_score=0'"
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 1" \
     "id:949060,\
@@ -104,7 +104,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 1" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl1}'"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
     "id:949160,\
@@ -113,7 +113,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl1}'"
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
     "id:949061,\
@@ -122,7 +122,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl2}'"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
     "id:949161,\
@@ -131,7 +131,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl2}'"
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
     "id:949062,\
@@ -140,7 +140,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl3}'"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
     "id:949162,\
@@ -149,7 +149,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl3}'"
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
     "id:949063,\
@@ -158,7 +158,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl4}'"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
     "id:949163,\
@@ -167,7 +167,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl4}'"
 SecMarker "BEGIN-REQUEST-BLOCKING-EVAL"
 SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
@@ -178,7 +178,7 @@ SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_thresh
     msg:'Inbound Anomaly Score Exceeded in phase 1 (Total Score: %{TX.BLOCKING_INBOUND_ANOMALY_SCORE})',\
     tag:'anomaly-evaluation',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     chain"
     SecRule TX:EARLY_BLOCKING "@eq 1"
 SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
@@ -189,13 +189,13 @@ SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_thresh
     msg:'Inbound Anomaly Score Exceeded (Total Score: %{TX.BLOCKING_INBOUND_ANOMALY_SCORE})',\
     tag:'anomaly-evaluation',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:949011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:949012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:949013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:949014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:949015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:949016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:949017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:949018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+    ver:'OWASP_CRS/4.10.0'"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:949011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:949012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:949013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:949014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:949015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:949016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:949017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:949018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
 SecMarker "END-REQUEST-949-BLOCKING-EVALUATION"

--- a/rules/@owasp_crs/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/@owasp_crs/RESPONSE-950-DATA-LEAKAGES.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -13,7 +13,7 @@ SecRule TX:crs_skip_response_analysis "@eq 1" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
 SecRule RESPONSE_HEADERS:Content-Encoding "@pm gzip compress deflate br zstd" \
     "id:950010,\
@@ -21,10 +21,10 @@ SecRule RESPONSE_HEADERS:Content-Encoding "@pm gzip compress deflate br zstd" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 SecRule RESPONSE_BODY "@rx (?:<(?:TITLE>Index of.*?<H|title>Index of.*?<h)1>Index of|>\[To Parent Directory\]</[Aa]><br>)" \
     "id:950130,\
     phase:4,\
@@ -41,7 +41,7 @@ SecRule RESPONSE_BODY "@rx (?:<(?:TITLE>Index of.*?<H|title>Index of.*?<h)1>Inde
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54/127',\
     tag:'PCI/6.5.6',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx ^#\!\s?/" \
@@ -60,11 +60,11 @@ SecRule RESPONSE_BODY "@rx ^#\!\s?/" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:950013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:950014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:950013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:950014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 SecRule RESPONSE_STATUS "@rx ^5\d{2}$" \
     "id:950100,\
     phase:3,\
@@ -81,11 +81,11 @@ SecRule RESPONSE_STATUS "@rx ^5\d{2}$" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/152',\
     tag:'PCI/6.5.6',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl2=+%{tx.error_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:950015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:950016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:950017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:950018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:950015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:950016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:950017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:950018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 SecMarker "END-RESPONSE-950-DATA-LEAKAGES"

--- a/rules/@owasp_crs/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/@owasp_crs/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -13,10 +13,10 @@ SecRule RESPONSE_HEADERS:Content-Encoding "@pm gzip compress deflate br zstd" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:951011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:951012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:951011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:951012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
 SecRule RESPONSE_BODY "!@pmFromFile sql-errors.data" \
     "id:951100,\
     phase:4,\
@@ -29,7 +29,7 @@ SecRule RESPONSE_BODY "!@pmFromFile sql-errors.data" \
     tag:'attack-disclosure',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     skipAfter:END-SQL-ERROR-MATCH-PL1"
 SecRule RESPONSE_BODY "@rx (?i:JET Database Engine|Access Database Engine|\[Microsoft\]\[ODBC Microsoft Access Driver\])" \
     "id:951110,\
@@ -46,7 +46,7 @@ SecRule RESPONSE_BODY "@rx (?i:JET Database Engine|Access Database Engine|\[Micr
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -65,7 +65,7 @@ SecRule RESPONSE_BODY "@rx (?i)\bORA-[0-9][0-9][0-9][0-9][0-9]:|java\.sql\.SQLEx
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -84,7 +84,7 @@ SecRule RESPONSE_BODY "@rx (?i:DB2 SQL error:|\[IBM\]\[CLI Driver\]\[DB2/6000\]|
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -103,7 +103,7 @@ SecRule RESPONSE_BODY "@rx (?i:\[DM_QUERY_E_SYNTAX\]|has occurred in the vicinit
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -122,7 +122,7 @@ SecRule RESPONSE_BODY "@rx (?i)Dynamic SQL Error" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -141,7 +141,7 @@ SecRule RESPONSE_BODY "@rx (?i)Exception (?:condition )?\d+\. Transaction rollba
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -160,7 +160,7 @@ SecRule RESPONSE_BODY "@rx (?i)org\.hsqldb\.jdbc" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -179,7 +179,7 @@ SecRule RESPONSE_BODY "@rx (?i:An illegal character has been found in the statem
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -198,7 +198,7 @@ SecRule RESPONSE_BODY "@rx (?i:Warning.*ingres_|Ingres SQLSTATE|Ingres\W.*Driver
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -217,7 +217,7 @@ SecRule RESPONSE_BODY "@rx (?i:<b>Warning</b>: ibase_|Unexpected end of command 
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -236,7 +236,7 @@ SecRule RESPONSE_BODY "@rx (?i:SQL error.*POS[0-9]+.*|Warning.*maxdb.*)" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -255,7 +255,7 @@ SecRule RESPONSE_BODY "@rx (?i)(?:System\.Data\.OleDb\.OleDbException|\[Microsof
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -274,7 +274,7 @@ SecRule RESPONSE_BODY "@rx (?i)(?:supplied argument is not a valid |SQL syntax.*
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -293,7 +293,7 @@ SecRule RESPONSE_BODY "@rx (?i)P(?:ostgreSQL(?: query failed:|.{1,20}ERROR)|G::[
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -312,7 +312,7 @@ SecRule RESPONSE_BODY "@rx (?i)(?:Warning.*sqlite_.*|Warning.*SQLite3::|SQLite/J
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -331,15 +331,15 @@ SecRule RESPONSE_BODY "@rx (?i)(?:Sybase message:|Warning.{2,20}sybase|Sybase.*S
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 SecMarker "END-SQL-ERROR-MATCH-PL1"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:951013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:951014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:951015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:951016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:951017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:951018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:951013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:951014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:951015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:951016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:951017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:951018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
 SecMarker "END-RESPONSE-951-DATA-LEAKAGES-SQL"

--- a/rules/@owasp_crs/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
+++ b/rules/@owasp_crs/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -13,10 +13,10 @@ SecRule RESPONSE_HEADERS:Content-Encoding "@pm gzip compress deflate br zstd" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:952011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:952012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:952011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:952012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
 SecRule RESPONSE_BODY "@pmFromFile java-code-leakages.data" \
     "id:952100,\
     phase:4,\
@@ -33,7 +33,7 @@ SecRule RESPONSE_BODY "@pmFromFile java-code-leakages.data" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 SecRule RESPONSE_BODY "@pmFromFile java-errors.data" \
@@ -52,13 +52,13 @@ SecRule RESPONSE_BODY "@pmFromFile java-errors.data" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:952013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:952014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:952015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:952016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:952017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:952018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:952013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:952014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:952015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:952016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:952017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:952018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
 SecMarker "END-RESPONSE-952-DATA-LEAKAGES-JAVA"

--- a/rules/@owasp_crs/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/@owasp_crs/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -13,10 +13,10 @@ SecRule RESPONSE_HEADERS:Content-Encoding "@pm gzip compress deflate br zstd" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:953011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:953012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:953011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:953012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
 SecRule RESPONSE_BODY "@pmFromFile php-errors.data" \
     "id:953100,\
     phase:4,\
@@ -33,7 +33,7 @@ SecRule RESPONSE_BODY "@pmFromFile php-errors.data" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx (?:\b(?:f(?:tp_(?:nb_)?f?(?:ge|pu)t|get(?:s?s|c)|scanf|write|open|read)|gz(?:(?:encod|writ)e|compress|open|read)|s(?:ession_start|candir)|read(?:(?:gz)?file|dir)|move_uploaded_file|(?:proc_|bz)open|call_user_func)|\$_(?:(?:pos|ge)t|session))\b" \
@@ -52,7 +52,7 @@ SecRule RESPONSE_BODY "@rx (?:\b(?:f(?:tp_(?:nb_)?f?(?:ge|pu)t|get(?:s?s|c)|scan
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx (?i)<\?(?:=|php)?\s+" \
@@ -71,11 +71,11 @@ SecRule RESPONSE_BODY "@rx (?i)<\?(?:=|php)?\s+" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:953013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:953014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:953013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:953014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
 SecRule RESPONSE_BODY "@pmFromFile php-errors-pl2.data" \
     "id:953101,\
     phase:4,\
@@ -92,11 +92,11 @@ SecRule RESPONSE_BODY "@pmFromFile php-errors-pl2.data" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl2=+%{tx.error_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:953015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:953016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:953017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:953018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:953015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:953016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:953017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:953018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
 SecMarker "END-RESPONSE-953-DATA-LEAKAGES-PHP"

--- a/rules/@owasp_crs/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+++ b/rules/@owasp_crs/RESPONSE-954-DATA-LEAKAGES-IIS.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -13,10 +13,10 @@ SecRule RESPONSE_HEADERS:Content-Encoding "@pm gzip compress deflate br zstd" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:954011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:954012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:954011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:954012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
 SecRule RESPONSE_BODY "@rx [a-z]:\x5cinetpub\b" \
     "id:954100,\
     phase:4,\
@@ -33,7 +33,7 @@ SecRule RESPONSE_BODY "@rx [a-z]:\x5cinetpub\b" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx (?:Microsoft OLE DB Provider for SQL Server(?:</font>.{1,20}?error '800(?:04005|40e31)'.{1,40}?Timeout expired| \(0x80040e31\)<br>Timeout expired<br>)|<h1>internal server error</h1>.*?<h2>part of the server has crashed or it has a configuration error\.</h2>|cannot connect to the server: timed out)" \
@@ -53,7 +53,7 @@ SecRule RESPONSE_BODY "@rx (?:Microsoft OLE DB Provider for SQL Server(?:</font>
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 SecRule RESPONSE_BODY "@pmFromFile iis-errors.data" \
@@ -73,7 +73,7 @@ SecRule RESPONSE_BODY "@pmFromFile iis-errors.data" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 SecRule RESPONSE_STATUS "!@rx ^404$" \
@@ -93,17 +93,17 @@ SecRule RESPONSE_STATUS "!@rx ^404$" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'ERROR',\
     chain"
     SecRule RESPONSE_BODY "@rx \bServer Error in.{0,50}?\bApplication\b" \
         "capture,\
         t:none,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:954013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:954014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:954015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:954016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:954017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:954018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:954013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:954014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:954015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:954016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:954017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:954018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
 SecMarker "END-RESPONSE-954-DATA-LEAKAGES-IIS"

--- a/rules/@owasp_crs/RESPONSE-955-WEB-SHELLS.conf
+++ b/rules/@owasp_crs/RESPONSE-955-WEB-SHELLS.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. (not) All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -13,10 +13,10 @@ SecRule RESPONSE_HEADERS:Content-Encoding "@pm gzip compress deflate br zstd" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     skipAfter:END-RESPONSE-955-WEB-SHELLS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:955011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:955012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:955011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:955012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
 SecRule RESPONSE_BODY "@pmFromFile web-shells-php.data" \
     "id:955100,\
     phase:4,\
@@ -31,7 +31,7 @@ SecRule RESPONSE_BODY "@pmFromFile web-shells-php.data" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx <title>r57 Shell Version [0-9.]+</title>|<title>r57 shell</title>" \
@@ -48,7 +48,7 @@ SecRule RESPONSE_BODY "@rx <title>r57 Shell Version [0-9.]+</title>|<title>r57 s
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx ^<html><head><meta http-equiv='Content-Type' content='text/html; charset=(?:Windows-1251|UTF-8)?'><title>.*?(?: -)? W[Ss][Oo] [0-9.]+</title>" \
@@ -65,7 +65,7 @@ SecRule RESPONSE_BODY "@rx ^<html><head><meta http-equiv='Content-Type' content=
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx B4TM4N SH3LL</title>.*<meta name='author' content='k4mpr3t'/>" \
@@ -82,7 +82,7 @@ SecRule RESPONSE_BODY "@rx B4TM4N SH3LL</title>.*<meta name='author' content='k4
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx <title>Mini Shell</title>.*Developed By LameHacker" \
@@ -99,7 +99,7 @@ SecRule RESPONSE_BODY "@rx <title>Mini Shell</title>.*Developed By LameHacker" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx <title>\.:: .* ~ Ashiyane V [0-9.]+ ::\.</title>" \
@@ -116,7 +116,7 @@ SecRule RESPONSE_BODY "@rx <title>\.:: .* ~ Ashiyane V [0-9.]+ ::\.</title>" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx <title>Symlink_Sa [0-9.]+</title>" \
@@ -133,7 +133,7 @@ SecRule RESPONSE_BODY "@rx <title>Symlink_Sa [0-9.]+</title>" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx <title>CasuS [0-9.]+ by MafiABoY</title>" \
@@ -150,7 +150,7 @@ SecRule RESPONSE_BODY "@rx <title>CasuS [0-9.]+ by MafiABoY</title>" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx ^<html>\r\n<head>\r\n<title>GRP WebShell [0-9.]+ " \
@@ -167,7 +167,7 @@ SecRule RESPONSE_BODY "@rx ^<html>\r\n<head>\r\n<title>GRP WebShell [0-9.]+ " \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx <small>NGHshell [0-9.]+ by Cr4sh</body></html>\n$" \
@@ -184,7 +184,7 @@ SecRule RESPONSE_BODY "@rx <small>NGHshell [0-9.]+ by Cr4sh</body></html>\n$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx <title>SimAttacker - (?:Version|Vrsion) : [0-9.]+ - " \
@@ -201,7 +201,7 @@ SecRule RESPONSE_BODY "@rx <title>SimAttacker - (?:Version|Vrsion) : [0-9.]+ - "
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx ^<!DOCTYPE html>\n<html>\n<!-- By Artyum .*<title>Web Shell</title>" \
@@ -218,7 +218,7 @@ SecRule RESPONSE_BODY "@rx ^<!DOCTYPE html>\n<html>\n<!-- By Artyum .*<title>Web
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx <title>lama's'hell v. [0-9.]+</title>" \
@@ -235,7 +235,7 @@ SecRule RESPONSE_BODY "@rx <title>lama's'hell v. [0-9.]+</title>" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx ^ *<html>\n[ ]+<head>\n[ ]+<title>lostDC - " \
@@ -252,7 +252,7 @@ SecRule RESPONSE_BODY "@rx ^ *<html>\n[ ]+<head>\n[ ]+<title>lostDC - " \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx ^<title>PHP Web Shell</title>\r\n<html>\r\n<body>\r\n    <!-- Replaces command with Base64-encoded Data -->" \
@@ -269,7 +269,7 @@ SecRule RESPONSE_BODY "@rx ^<title>PHP Web Shell</title>\r\n<html>\r\n<body>\r\n
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx ^<html>\n<head>\n<div align=\"left\"><font size=\"1\">Input command :</font></div>\n<form name=\"cmd\" method=\"POST\" enctype=\"multipart/form-data\">" \
@@ -286,7 +286,7 @@ SecRule RESPONSE_BODY "@rx ^<html>\n<head>\n<div align=\"left\"><font size=\"1\"
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx ^<html>\n<head>\n<title>Ru24PostWebShell " \
@@ -303,7 +303,7 @@ SecRule RESPONSE_BODY "@rx ^<html>\n<head>\n<title>Ru24PostWebShell " \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx <title>s72 Shell v[0-9.]+ Codinf by Cr@zy_King</title>" \
@@ -320,7 +320,7 @@ SecRule RESPONSE_BODY "@rx <title>s72 Shell v[0-9.]+ Codinf by Cr@zy_King</title
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx ^<html>\r\n<head>\r\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=gb2312\">\r\n<title>PhpSpy Ver [0-9]+</title>" \
@@ -337,7 +337,7 @@ SecRule RESPONSE_BODY "@rx ^<html>\r\n<head>\r\n<meta http-equiv=\"Content-Type\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx ^ <html>\n\n<head>\n\n<title>g00nshell v[0-9.]+ " \
@@ -354,7 +354,7 @@ SecRule RESPONSE_BODY "@rx ^ <html>\n\n<head>\n\n<title>g00nshell v[0-9.]+ " \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@contains <title>punkholicshell</title>" \
@@ -371,7 +371,7 @@ SecRule RESPONSE_BODY "@contains <title>punkholicshell</title>" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx ^<html>\n      <head>\n             <title>azrail [0-9.]+ by C-W-M</title>" \
@@ -388,7 +388,7 @@ SecRule RESPONSE_BODY "@rx ^<html>\n      <head>\n             <title>azrail [0-
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx >SmEvK_PaThAn Shell v[0-9]+ coded by <a href=" \
@@ -405,7 +405,7 @@ SecRule RESPONSE_BODY "@rx >SmEvK_PaThAn Shell v[0-9]+ coded by <a href=" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx ^<html>\n<title>.*? ~ Shell I</title>\n<head>\n<style>" \
@@ -422,7 +422,7 @@ SecRule RESPONSE_BODY "@rx ^<html>\n<title>.*? ~ Shell I</title>\n<head>\n<style
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 SecRule RESPONSE_BODY "@rx ^ <html><head><title>:: b374k m1n1 [0-9.]+ ::</title>" \
@@ -439,11 +439,11 @@ SecRule RESPONSE_BODY "@rx ^ <html><head><title>:: b374k m1n1 [0-9.]+ ::</title>
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:955013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:955014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:955013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:955014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
 SecRule RESPONSE_BODY "@contains <h1 style=\"margin-bottom: 0\">webadmin.php</h1>" \
     "id:955350,\
     phase:4,\
@@ -458,11 +458,11 @@ SecRule RESPONSE_BODY "@contains <h1 style=\"margin-bottom: 0\">webadmin.php</h1
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:955015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:955016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:955017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:955018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:955015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:955016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:955017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:955018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
 SecMarker "END-RESPONSE-955-WEB-SHELLS"

--- a/rules/@owasp_crs/RESPONSE-959-BLOCKING-EVALUATION.conf
+++ b/rules/@owasp_crs/RESPONSE-959-BLOCKING-EVALUATION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -14,7 +14,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 1" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl1}'"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
     "id:959152,\
@@ -23,7 +23,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl1}'"
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
     "id:959053,\
@@ -32,7 +32,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl2}'"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
     "id:959153,\
@@ -41,7 +41,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl2}'"
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
     "id:959054,\
@@ -50,7 +50,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl3}'"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
     "id:959154,\
@@ -59,7 +59,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl3}'"
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
     "id:959055,\
@@ -68,7 +68,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl4}'"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
     "id:959155,\
@@ -77,7 +77,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl4}'"
 SecAction \
     "id:959059,\
@@ -86,7 +86,7 @@ SecAction \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.blocking_outbound_anomaly_score=0'"
 SecAction \
     "id:959159,\
@@ -95,7 +95,7 @@ SecAction \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.detection_outbound_anomaly_score=0'"
 SecMarker "EARLY_BLOCKING_ANOMALY_SCORING"
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 1" \
@@ -105,7 +105,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 1" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl1}'"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
     "id:959160,\
@@ -114,7 +114,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl1}'"
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
     "id:959061,\
@@ -123,7 +123,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl2}'"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
     "id:959161,\
@@ -132,7 +132,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl2}'"
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
     "id:959062,\
@@ -141,7 +141,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl3}'"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
     "id:959162,\
@@ -150,7 +150,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl3}'"
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
     "id:959063,\
@@ -159,7 +159,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl4}'"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
     "id:959163,\
@@ -168,7 +168,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl4}'"
 SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
     "id:959101,\
@@ -178,7 +178,7 @@ SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_thre
     msg:'Outbound Anomaly Score Exceeded in phase 3 (Total Score: %{tx.blocking_outbound_anomaly_score})',\
     tag:'anomaly-evaluation',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     chain"
     SecRule TX:EARLY_BLOCKING "@eq 1"
 SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
@@ -189,13 +189,13 @@ SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_thre
     msg:'Outbound Anomaly Score Exceeded (Total Score: %{tx.blocking_outbound_anomaly_score})',\
     tag:'anomaly-evaluation',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0'"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:959011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:959012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:959013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:959014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:959015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:959016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:959017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:959018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+    ver:'OWASP_CRS/4.10.0'"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:959011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:959012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:959013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:959014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:959015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:959016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:959017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:959018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
 SecMarker "END-RESPONSE-959-BLOCKING-EVALUATION"

--- a/rules/@owasp_crs/RESPONSE-980-CORRELATION.conf
+++ b/rules/@owasp_crs/RESPONSE-980-CORRELATION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.9.0
+# OWASP CRS ver.4.10.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2024 CRS project. All rights reserved.
 #
@@ -15,24 +15,24 @@ SecAction \
     nolog,\
     noauditlog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0',\
+    ver:'OWASP_CRS/4.10.0',\
     setvar:'tx.blocking_anomaly_score=%{tx.blocking_inbound_anomaly_score}',\
     setvar:'tx.blocking_anomaly_score=+%{tx.blocking_outbound_anomaly_score}',\
     setvar:'tx.detection_anomaly_score=%{tx.detection_inbound_anomaly_score}',\
     setvar:'tx.detection_anomaly_score=+%{tx.detection_outbound_anomaly_score}',\
     setvar:'tx.anomaly_score=%{tx.blocking_inbound_anomaly_score}',\
     setvar:'tx.anomaly_score=+%{tx.blocking_outbound_anomaly_score}'"
-SecRule TX:REPORTING_LEVEL "@eq 0" "id:980041,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REPORTING"
-SecRule TX:REPORTING_LEVEL "@ge 5" "id:980042,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:LOG-REPORTING"
-SecRule TX:DETECTION_ANOMALY_SCORE "@eq 0" "id:980043,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REPORTING"
-SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" "id:980044,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:LOG-REPORTING"
-SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" "id:980045,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:LOG-REPORTING"
-SecRule TX:REPORTING_LEVEL "@lt 2" "id:980046,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REPORTING"
-SecRule TX:DETECTION_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" "id:980047,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:LOG-REPORTING"
-SecRule TX:DETECTION_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" "id:980048,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:LOG-REPORTING"
-SecRule TX:REPORTING_LEVEL "@lt 3" "id:980049,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REPORTING"
-SecRule TX:BLOCKING_ANOMALY_SCORE "@gt 0" "id:980050,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:LOG-REPORTING"
-SecRule TX:REPORTING_LEVEL "@lt 4" "id:980051,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-REPORTING"
+SecRule TX:REPORTING_LEVEL "@eq 0" "id:980041,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REPORTING"
+SecRule TX:REPORTING_LEVEL "@ge 5" "id:980042,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:LOG-REPORTING"
+SecRule TX:DETECTION_ANOMALY_SCORE "@eq 0" "id:980043,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REPORTING"
+SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" "id:980044,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:LOG-REPORTING"
+SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" "id:980045,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:LOG-REPORTING"
+SecRule TX:REPORTING_LEVEL "@lt 2" "id:980046,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REPORTING"
+SecRule TX:DETECTION_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" "id:980047,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:LOG-REPORTING"
+SecRule TX:DETECTION_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" "id:980048,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:LOG-REPORTING"
+SecRule TX:REPORTING_LEVEL "@lt 3" "id:980049,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REPORTING"
+SecRule TX:BLOCKING_ANOMALY_SCORE "@gt 0" "id:980050,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:LOG-REPORTING"
+SecRule TX:REPORTING_LEVEL "@lt 4" "id:980051,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-REPORTING"
 SecMarker "LOG-REPORTING"
 SecAction \
     "id:980170,\
@@ -46,14 +46,14 @@ SecAction \
 (SQLI=%{tx.sql_injection_score}, XSS=%{tx.xss_score}, RFI=%{tx.rfi_score}, LFI=%{tx.lfi_score}, RCE=%{tx.rce_score}, PHPI=%{tx.php_injection_score}, HTTP=%{tx.http_violation_score}, SESS=%{tx.session_fixation_score}, COMBINED_SCORE=%{tx.anomaly_score})',\
     tag:'reporting',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.9.0'"
+    ver:'OWASP_CRS/4.10.0'"
 SecMarker "END-REPORTING"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:980011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-980-CORRELATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:980012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-980-CORRELATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:980013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-980-CORRELATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:980014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-980-CORRELATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:980015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-980-CORRELATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:980016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-980-CORRELATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:980017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-980-CORRELATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:980018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.9.0',skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:980011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:980012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:980013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:980014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:980015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:980016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:980017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:980018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.10.0',skipAfter:END-RESPONSE-980-CORRELATION"
 SecMarker "END-RESPONSE-980-CORRELATION"

--- a/rules/@owasp_crs/restricted-files.data
+++ b/rules/@owasp_crs/restricted-files.data
@@ -157,6 +157,7 @@ defaults.inc.php
 sendgrid.env
 .fish
 fish_variables
+ldap-authentication-report.csv
 proc/0
 proc/1
 proc/2

--- a/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920221.yaml
+++ b/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920221.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "Max Leske, azurit"
+  author: "Max Leske, azurit, TimDiam0nd"
   description: "Detect invalid URI encoding in the last path segment of the URI"
 rule_id: 920221
 tests:
@@ -26,6 +26,21 @@ tests:
           dest_addr: "127.0.0.1"
           port: 80
           uri: "/get/%25w20.txt"
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: "localhost"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [920221]
+  - test_id: 3
+    desc: Do not match on an empty last path segment
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          port: 80
+          uri: "/get/"
           headers:
             User-Agent: "OWASP CRS test agent"
             Host: "localhost"

--- a/tests/REQUEST-922-MULTIPART-ATTACK/922130.yaml
+++ b/tests/REQUEST-922-MULTIPART-ATTACK/922130.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "Ervin Hegedus"
+  author: "Ervin Hegedus, TimDiam0nd"
   description: Test Multipart/form-data
 rule_id: 922130
 tests:
@@ -166,3 +166,26 @@ tests:
             # The rule will match when an older version of the engine doesn't fail parsing. In newer versions of the engine,
             # parsing will fail and the body will be considered invalid.
             match_regex: 'Multipart parsing error: Multipart: Invalid part header \(contains invalid character\)|\[id "922130"\].*\[msg "Multipart header contains characters outside of valid range"\]'
+  - test_id: 8
+    desc: Negative test - do not match when there are no multipart headers.
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: "localhost"
+            User-Agent: "OWASP CRS test agent"
+            Content-Type: multipart/form-data; boundary=boundary123
+            Accept: "*/*"
+          method: POST
+          port: 80
+          uri: "/post"
+          version: "HTTP/1.1"
+          data: |
+            --boundary123
+            test
+            --boundary123
+            yet another test
+            --boundary123--
+        output:
+          log:
+            no_expect_ids: [922130]

--- a/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933135.yaml
+++ b/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933135.yaml
@@ -1,0 +1,185 @@
+---
+meta:
+  author: "azurit"
+rule_id: 933135
+tests:
+  - test_id: 1
+    desc: "${'ff'}"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Accept-Encoding: gzip,deflate
+            Accept-Language: en-us,en;q=0.5
+            Host: localhost
+            Keep-Alive: '300'
+            Proxy-Connection: keep-alive
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/get?foo=%24%7B%27ff%27%7D"
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [933135]
+  - test_id: 2
+    desc: "$ {'fdf'}"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Accept-Encoding: gzip,deflate
+            Accept-Language: en-us,en;q=0.5
+            Host: localhost
+            Keep-Alive: '300'
+            Proxy-Connection: keep-alive
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/get?foo=%24%20%7B%27fdf%27%7D"
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [933135]
+  - test_id: 3
+    desc: "$              {$a}"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Accept-Encoding: gzip,deflate
+            Accept-Language: en-us,en;q=0.5
+            Host: localhost
+            Keep-Alive: '300'
+            Proxy-Connection: keep-alive
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/get?foo=%24%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7B%24a%7D"
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [933135]
+  - test_id: 4
+    desc: "$ {'_VAR'.'IABLE_NAME'}"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Accept-Encoding: gzip,deflate
+            Accept-Language: en-us,en;q=0.5
+            Host: localhost
+            Keep-Alive: '300'
+            Proxy-Connection: keep-alive
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/get?foo=%24%20%7B%27_VAR%27.%27IABLE_NAME%27%7D"
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [933135]
+  - test_id: 5
+    desc: "$              {         $a}"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Accept-Encoding: gzip,deflate
+            Accept-Language: en-us,en;q=0.5
+            Host: localhost
+            Keep-Alive: '300'
+            Proxy-Connection: keep-alive
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/get?foo=%24%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7B%20%20%20%20%20%20%20%20%20%24a%7D"
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [933135]
+  - test_id: 6
+    desc: "$     {   CONSTANT   }"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Accept-Encoding: gzip,deflate
+            Accept-Language: en-us,en;q=0.5
+            Host: localhost
+            Keep-Alive: '300'
+            Proxy-Connection: keep-alive
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/get?foo=%24%20%20%20%20%20%7B%20%20%20CONSTANT%20%20%20%7D"
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [933135]
+  - test_id: 7
+    desc: "${}"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Accept-Encoding: gzip,deflate
+            Accept-Language: en-us,en;q=0.5
+            Host: localhost
+            Keep-Alive: '300'
+            Proxy-Connection: keep-alive
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/get?foo=%24%7B%7D"
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids: [933135]
+  - test_id: 8
+    desc: "$ { }"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Accept-Encoding: gzip,deflate
+            Accept-Language: en-us,en;q=0.5
+            Host: localhost
+            Keep-Alive: '300'
+            Proxy-Connection: keep-alive
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/get?foo=%24%20%7B%20%7D"
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids: [933135]
+  - test_id: 9
+    desc: "${a}"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Accept-Encoding: gzip,deflate
+            Accept-Language: en-us,en;q=0.5
+            Host: localhost
+            Keep-Alive: '300'
+            Proxy-Connection: keep-alive
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/get?foo=%24%7Ba%7D"
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [933135]

--- a/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941130.yaml
+++ b/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941130.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "csanders-git, Christian Folini, azurit"
+  author: "csanders-git, Christian Folini, azurit, Max Leske"
 rule_id: 941130
 tests:
   - test_id: 1
@@ -323,3 +323,37 @@ tests:
         output:
           log:
             expect_ids: [941130]
+  - test_id: 20
+    desc: "True positive for `pattern` attribute"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          method: POST
+          port: 80
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/post"
+          data: 'var=<input pattern="^a regex$">'
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [941130]
+  - test_id: 21
+    desc: "False positive for `pattern` with `=` following at an arbitrary position later"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          method: POST
+          port: 80
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/post"
+          data: "var=There's a pattern in the dark background. Here's a video: <a href=\\x22https://www.youtube.com/watch?v="
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids: [941130]

--- a/version.go
+++ b/version.go
@@ -7,6 +7,6 @@
 package main
 
 const (
-	crsVersion    = "v4.9.0"
+	crsVersion    = "v4.10.0"
 	corazaVersion = "v3.3.3"
 )


### PR DESCRIPTION
Follows https://github.com/corazawaf/coraza-coreruleset/pull/42. Same goal:
> The goal is to still have all the CRS version tagged, so the plan is to manually open the PRs up to the current CRS version, from which https://github.com/corazawaf/coraza-coreruleset/pull/31 will pick one by one as soon as they are out.